### PR TITLE
perpare to merge with ossgang-properties-core

### DIFF
--- a/src/main/java/io/github/ossgang/commons/observable/DerivedObservableValue.java
+++ b/src/main/java/io/github/ossgang/commons/observable/DerivedObservableValue.java
@@ -10,9 +10,9 @@ import static io.github.ossgang.commons.observable.Observable.ObservableSubscrip
 import static java.util.Collections.newSetFromMap;
 
 /**
- * An {@link ObservableValue} which gets its data from a parent (upstream) {@link ObservableValue}, applying a
- * transformation. Transformations can include arbitrary mapping and/or filtering. If a transformation fails (the
- * mapping function throws), a warning is issued and the value is discarded.
+ * An {@link ObservableValue} which gets its data from a parent (upstream) {@link ObservableValue} or {@link Observable},
+ * applying a transformation. Transformations can include arbitrary mapping and/or filtering. If a transformation fails
+ * (the mapping function throws), a warning is issued and the value is discarded.
  *
  * The subscription to the upstream observable is eager (as soon as this class is instantiated), even if there are no
  * subscribers.
@@ -31,9 +31,13 @@ public class DerivedObservableValue<S,D> extends DispatchingObservableValue<D> i
     private final Function<S, Optional<D>> mapper;
 
     DerivedObservableValue(ObservableValue<S> sourceObservable, Function<S, Optional<D>> mapper) {
+        this(sourceObservable, sourceObservable.get(), mapper);
+    }
+
+    DerivedObservableValue(Observable<S> sourceObservable, S initialValue, Function<S, Optional<D>> mapper) {
         super(null);
         this.mapper = mapper;
-        Optional.ofNullable(sourceObservable.get()).ifPresent(this::deriveUpdate);
+        Optional.ofNullable(initialValue).ifPresent(this::deriveUpdate);
         sourceObservable.subscribe(this::deriveUpdate, WEAK);
     }
 

--- a/src/main/java/io/github/ossgang/commons/observable/DispatchingObservableValue.java
+++ b/src/main/java/io/github/ossgang/commons/observable/DispatchingObservableValue.java
@@ -25,8 +25,6 @@ package io.github.ossgang.commons.observable;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 import static io.github.ossgang.commons.observable.ObservableValue.ObservableValueSubscriptionOption.FIRST_UPDATE;
 import static io.github.ossgang.commons.observable.ObservableValue.ObservableValueSubscriptionOption.ON_CHANGE;
@@ -55,16 +53,6 @@ public class DispatchingObservableValue<T> extends DispatchingObservable<T> impl
             Optional.ofNullable(lastValue.get()).ifPresent(listener);
         }
         return super.subscribe(listener, options);
-    }
-
-    @Override
-    public <D> ObservableValue<D> map(Function<T, D> mapper) {
-        return new DerivedObservableValue<>(this, mapper.andThen(Optional::of));
-    }
-
-    @Override
-    public ObservableValue<T> filter(Predicate<T> filter) {
-        return new DerivedObservableValue<>(this, v -> Optional.of(v).filter(filter));
     }
 
     @Override

--- a/src/main/java/io/github/ossgang/commons/observable/ObservableValue.java
+++ b/src/main/java/io/github/ossgang/commons/observable/ObservableValue.java
@@ -22,6 +22,7 @@
 
 package io.github.ossgang.commons.observable;
 
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -60,7 +61,9 @@ public interface ObservableValue<T> extends Observable<T> {
      * @param <D> the destination type
      * @return the derived observable
      */
-    <D> ObservableValue<D> map(Function<T, D> mapper);
+    default <D> ObservableValue<D> map(Function<T, D> mapper) {
+        return new DerivedObservableValue<>(this, mapper.andThen(Optional::of));
+    }
 
     /**
      * Create a derived observable value applying a filtering function to the updates of this one. Values which do not
@@ -69,5 +72,8 @@ public interface ObservableValue<T> extends Observable<T> {
      * @param filter the filter to apply
      * @return the derived observable
      */
-    ObservableValue<T> filter(Predicate<T> filter);
+    default ObservableValue<T> filter(Predicate<T> filter) {
+        return new DerivedObservableValue<>(this, v -> Optional.of(v).filter(filter));
+    }
+
 }

--- a/src/main/java/io/github/ossgang/commons/observable/Observables.java
+++ b/src/main/java/io/github/ossgang/commons/observable/Observables.java
@@ -1,0 +1,28 @@
+package io.github.ossgang.commons.observable;
+
+import java.util.Optional;
+
+/**
+ * Static support class for dealing with {@link Observable} and {@link ObservableValue}.
+ */
+public class Observables {
+    private Observables() {
+        throw new UnsupportedOperationException("static only");
+    }
+
+    /**
+     * Create an {@link ObservableValue} from any {@link Observable}. If the observable passed in is an instance of
+     * {@link ObservableValue}, it is returned unchanged. Otherwise, a derived observable value is created which
+     * subscribes to the upstream observable and caches its latest value.
+     *
+     * @param observable the observable
+     * @param <T> the type
+     * @return an {@link ObservableValue} reflecting the observable provided
+     */
+    public static <T> ObservableValue<T> observableValueOf(Observable<T> observable) {
+        if (observable instanceof ObservableValue) {
+            return (ObservableValue<T>) observable;
+        }
+        return new DerivedObservableValue<>(observable, null, Optional::of);
+    }
+}

--- a/src/main/java/io/github/ossgang/commons/property/Properties.java
+++ b/src/main/java/io/github/ossgang/commons/property/Properties.java
@@ -20,15 +20,35 @@
  ******************************************************************************/
 // @formatter:on
 
-package io.github.ossgang.commons.observable;
+package io.github.ossgang.commons.property;
 
-public class SimpleProperty<T> extends DispatchingObservableValue<T> implements Property<T> {
-    SimpleProperty(T initial) {
-        super(initial);
+/**
+ * Static entry point to create properties.
+ */
+public class Properties {
+    private Properties() {
+        throw new UnsupportedOperationException("static only");
     }
 
-    @Override
-    public void set(T value) {
-        update(value);
+    /**
+     * Create a {@link Property} with an initial value.
+     *
+     * @param initialValue the initial value
+     * @param <T> the type
+     * @return the new property
+     */
+    public static <T> Property<T> property(T initialValue) {
+        return new SimpleProperty<>(initialValue);
     }
+
+    /**
+     * Create a {@link Property} with NO initial value.
+     *
+     * @param <T> the type
+     * @return the new property
+     */
+    public static <T> Property<T> property() {
+        return new SimpleProperty<>(null);
+    }
+
 }

--- a/src/main/java/io/github/ossgang/commons/property/Property.java
+++ b/src/main/java/io/github/ossgang/commons/property/Property.java
@@ -20,35 +20,22 @@
  ******************************************************************************/
 // @formatter:on
 
-package io.github.ossgang.commons.observable;
+package io.github.ossgang.commons.property;
+
+import io.github.ossgang.commons.observable.ObservableValue;
 
 /**
- * Static entry point to create properties.
+ * A "property": an {@link ObservableValue} which can be set.
+ *
+ * @param <T> the type of the property
  */
-public class Properties {
-    private Properties() {
-        throw new UnsupportedOperationException("static only");
-    }
-
+public interface Property<T> extends ObservableValue<T> {
     /**
-     * Create a {@link Property} with an initial value.
+     * Set the property to the given value, notifying all observers.
+     * The new value must not be null.
      *
-     * @param initialValue the initial value
-     * @param <T> the type
-     * @return the new property
+     * @param value the new value.
+     * @throws NullPointerException on a null value
      */
-    public static <T> Property<T> property(T initialValue) {
-        return new SimpleProperty<>(initialValue);
-    }
-
-    /**
-     * Create a {@link Property} with NO initial value.
-     *
-     * @param <T> the type
-     * @return the new property
-     */
-    public static <T> Property<T> property() {
-        return new SimpleProperty<>(null);
-    }
-
+    void set(T value);
 }

--- a/src/main/java/io/github/ossgang/commons/property/SimpleProperty.java
+++ b/src/main/java/io/github/ossgang/commons/property/SimpleProperty.java
@@ -20,20 +20,17 @@
  ******************************************************************************/
 // @formatter:on
 
-package io.github.ossgang.commons.observable;
+package io.github.ossgang.commons.property;
 
-/**
- * A "property": an {@link ObservableValue} which can be set.
- *
- * @param <T> the type of the property
- */
-public interface Property<T> extends ObservableValue<T> {
-    /**
-     * Set the property to the given value, notifying all observers.
-     * The new value must not be null.
-     *
-     * @param value the new value.
-     * @throws NullPointerException on a null value
-     */
-    void set(T value);
+import io.github.ossgang.commons.observable.DispatchingObservableValue;
+
+public class SimpleProperty<T> extends DispatchingObservableValue<T> implements Property<T> {
+    SimpleProperty(T initial) {
+        super(initial);
+    }
+
+    @Override
+    public void set(T value) {
+        update(value);
+    }
 }

--- a/src/main/java/io/github/ossgang/commons/property/WrapperProperty.java
+++ b/src/main/java/io/github/ossgang/commons/property/WrapperProperty.java
@@ -1,0 +1,55 @@
+// @formatter:off
+/*******************************************************************************
+ *
+ * This file is part of ossgang-commons.
+ *
+ * Copyright (c) 2008-2019, CERN. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+// @formatter:on
+
+package io.github.ossgang.commons.property;
+
+import io.github.ossgang.commons.observable.ObservableValue;
+import io.github.ossgang.commons.observable.Subscription;
+import io.github.ossgang.commons.observable.SubscriptionOption;
+
+import java.util.function.Consumer;
+
+public class WrapperProperty<T> implements Property<T>, ObservableValue<T> {
+    private final ObservableValue<T> observableValue;
+    private final Consumer<? super T> setConsumer;
+
+    WrapperProperty(ObservableValue<T> updateProvider, Consumer<? super T> setConsumer) {
+        this.observableValue = updateProvider;
+        this.setConsumer = setConsumer;
+    }
+
+    @Override
+    public void set(T value) {
+        setConsumer.accept(value);
+    }
+
+    @Override
+    public T get() {
+        return observableValue.get();
+    }
+
+
+    @Override
+    public Subscription subscribe(Consumer<? super T> listener, SubscriptionOption... options) {
+        return observableValue.subscribe(listener, options);
+    }
+}

--- a/src/test/java/io/github/ossgang/commons/observable/SimplePropertyTest.java
+++ b/src/test/java/io/github/ossgang/commons/observable/SimplePropertyTest.java
@@ -1,5 +1,7 @@
 package io.github.ossgang.commons.observable;
 
+import io.github.ossgang.commons.property.Properties;
+import io.github.ossgang.commons.property.Property;
 import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;

--- a/src/test/java/io/github/ossgang/commons/property/SimplePropertyTest.java
+++ b/src/test/java/io/github/ossgang/commons/property/SimplePropertyTest.java
@@ -1,7 +1,6 @@
-package io.github.ossgang.commons.observable;
+package io.github.ossgang.commons.property;
 
-import io.github.ossgang.commons.property.Properties;
-import io.github.ossgang.commons.property.Property;
+import io.github.ossgang.commons.observable.ObservableValue;
 import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;


### PR DESCRIPTION
This is a small refactoring and re-structuring to prepare for a merge with ossgang-properties-core:
- split off properties in a separate package (for clarity, there might be more stuff coming up there)
- create the equivalent of the WrapperProperty class which has independent set() and get/observe
- create an utility class for Observables
- allow to create ObservableValue from Observable (cache last) - will be used for interfacing with Fluxes I presume.