### PR TITLE
Move GC protection to base DispatchingObservable

### DIFF
--- a/src/main/java/org/ossgang/commons/observable/DerivedObservableValue.java
+++ b/src/main/java/org/ossgang/commons/observable/DerivedObservableValue.java
@@ -1,11 +1,8 @@
 package org.ossgang.commons.observable;
 
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
-import static java.util.Collections.newSetFromMap;
 import static org.ossgang.commons.monads.Maybe.attempt;
 import static org.ossgang.commons.observable.ObservableValue.ObservableValueSubscriptionOption.FIRST_UPDATE;
 import static org.ossgang.commons.observable.WeakObservers.weakWithErrorAndSubscriptionCountHandling;
@@ -13,22 +10,20 @@ import static org.ossgang.commons.observable.WeakObservers.weakWithErrorAndSubsc
 /**
  * An {@link ObservableValue} which gets its data from a parent (upstream) {@link ObservableValue} or {@link Observable},
  * applying a transformation. Transformations can include arbitrary mapping and/or filtering. If a transformation fails
- * (the mapping function throws), a warning is issued and the value is discarded.
+ * (the mapping function throws), the exception is propagated downstream.
  * <p>
  * The subscription to the upstream observable is eager (as soon as this class is instantiated), even if there are no
  * subscribers.
  * <p>
- * This class makes sure that it will not be garbage collected as long as there is at least one subscriber subscribed
- * to the observable. If there are no subscribers to a derived observable, it becomes garbage collectible (provided
- * that no other references to it exist).
- * <p>
  * There is no guarantee that a call to get() will return the latest item of the upstream observable.
+ * <p>
+ * Objects of this class hold a strong reference to the source observable, preventing it from being GC'd as long as
+ * they exist.
  *
  * @param <S> the type of the source observable
  * @param <D> the type of this observable
  */
 public class DerivedObservableValue<S, D> extends DispatchingObservableValue<D> implements ObservableValue<D> {
-    private final static Set<DerivedObservableValue<?, ?>> GC_PROTECTION = newSetFromMap(new ConcurrentHashMap<>());
     private final Function<S, Optional<D>> mapper;
     private final Observable<S> sourceObservable;
 
@@ -59,15 +54,5 @@ public class DerivedObservableValue<S, D> extends DispatchingObservableValue<D> 
                allowing GC'ing this derived value. */
             unsubscribeAllObservers();
         }
-    }
-
-    @Override
-    protected void firstListenerAdded() {
-        GC_PROTECTION.add(this);
-    }
-
-    @Override
-    protected void lastListenerRemoved() {
-        GC_PROTECTION.remove(this);
     }
 }

--- a/src/test/java/org/ossgang/commons/GcTests.java
+++ b/src/test/java/org/ossgang/commons/GcTests.java
@@ -1,0 +1,26 @@
+package org.ossgang.commons;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Test Creation Utility For GC-bases Tests
+ */
+public class GcTests {
+    private GcTests() {
+        throw new UnsupportedOperationException("static only");
+    }
+
+    /**
+     * Force the GC to run a few times. Note that (in Oracles JVM) multiple GC runs are needed to resolve indirections
+     * and cycles, therefore this methods makes sure that the GC run at least 10 times.
+     */
+    public static void forceGc() {
+        for (int run = 0; run < 10; run++) {
+            WeakReference<?> ref = new WeakReference<>(new Object());
+            while (ref.get() != null) {
+                System.gc();
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/ossgang/commons/observable/ObservableValueGcTest.java
+++ b/src/test/java/org/ossgang/commons/observable/ObservableValueGcTest.java
@@ -1,0 +1,68 @@
+package org.ossgang.commons.observable;
+
+import org.junit.Test;
+import org.ossgang.commons.property.Properties;
+import org.ossgang.commons.property.Property;
+
+import java.lang.ref.WeakReference;
+import java.util.HashSet;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ossgang.commons.GcTests.forceGc;
+
+public class ObservableValueGcTest {
+    private CompletableFuture<Integer> methodReferenceUpdateValue = new CompletableFuture<>();
+
+    private void handleUpdate(int test) {
+        methodReferenceUpdateValue.complete(test);
+    }
+
+    @Test
+    public void gcWhileSubscribed_shouldPreventGc() throws Exception {
+        WeakReference<Property<Integer>> weakProp = gcWhileSubscribed_shouldPreventGc_subscribe();
+        forceGc();
+        Property<Integer> prop = weakProp.get();
+        assertThat(prop).isNotNull();
+        prop.set(2);
+        assertThat(methodReferenceUpdateValue.get(1, SECONDS)).isEqualTo(2);
+    }
+
+    private WeakReference<Property<Integer>> gcWhileSubscribed_shouldPreventGc_subscribe() {
+        Property<Integer> property = Properties.property(1);
+        property.subscribe(this::handleUpdate);
+        return new WeakReference<>(property);
+    }
+
+    @Test
+    public void gcWhileNotSubscribed_shouldGc() {
+        WeakReference<Property<Integer>> derivedObservable = gcWhileNotSubscribed_shouldGc_makeProperty();
+        assertThat(derivedObservable.get()).isNotNull();
+        forceGc();
+        assertThat(derivedObservable.get()).isNull();
+    }
+
+    private WeakReference<Property<Integer>> gcWhileNotSubscribed_shouldGc_makeProperty() {
+        Property<Integer> property = Properties.property(1);
+        return new WeakReference<>(property);
+    }
+
+    @Test
+    public void gcAfterUnsubscribe_shouldGc() {
+        WeakReference<Property<Integer>> weakProp = gcAfterUnsubscribe_shouldGc_subscribeAndUnsubscribe();
+        forceGc();
+        Property<Integer> prop = weakProp.get();
+        assertThat(prop).isNull();
+    }
+
+    private WeakReference<Property<Integer>> gcAfterUnsubscribe_shouldGc_subscribeAndUnsubscribe() {
+        Property<Integer> property = Properties.property(1);
+        HashSet<Subscription> subscriptions = new HashSet<>();
+        for (int i=0; i<100; i++) {
+            subscriptions.add(property.subscribe(this::handleUpdate));
+        }
+        subscriptions.forEach(Subscription::unsubscribe);
+        return new WeakReference<>(property);
+    }
+}


### PR DESCRIPTION
Move the behavior that observables which hold active subscriptions are GC-protected from "derived observable" to the base class.

This makes sure that any observables inheriting from DispatchingObservable (=everything within the framework) will share behavior. Custom observable implementations should implement it as well.