### PR TITLE
first proposal for a framework-wide "uncaught" exception handler

### DIFF
--- a/src/main/java/org/ossgang/commons/observable/Observables.java
+++ b/src/main/java/org/ossgang/commons/observable/Observables.java
@@ -1,6 +1,7 @@
 package org.ossgang.commons.observable;
 
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
@@ -194,6 +195,23 @@ public class Observables {
      */
     public static <I> ObservableValue<List<I>> combineLatest(List<ObservableValue<I>> sources) {
         return combineLatest(sources, Function.identity());
+    }
+
+    /**
+     * Sets a static, framework-wide uncaught exception handler. It is called in the following cases:
+     * <ul>
+     *     <li>If an observer onNext/onException throws, with an {@link UpdateDeliveryException}</li>
+     *     <li>If an observer does not implement onException and an exception would be delivered, by
+     *     an {@link UnhandledException}</li>
+     * </ul>
+     * In either case, getCause() can be used to obtain the original exception.
+     *
+     * @see UpdateDeliveryException
+     * @see UnhandledException
+     * @param handler the exception handler to be called
+     */
+    public static void setUncaughtExceptionHandler(Consumer<Exception> handler) {
+        DispatchingObservable.setUncaughtExceptionHandler(handler);
     }
 
     private static <V> Map<Integer, V> toIndexMap(List<V> list) {

--- a/src/main/java/org/ossgang/commons/observable/Observer.java
+++ b/src/main/java/org/ossgang/commons/observable/Observer.java
@@ -8,7 +8,7 @@ package org.ossgang.commons.observable;
 public interface Observer<T> {
     void onValue(T value);
 
-    default void onException(Throwable exception) {};
+    default void onException(Throwable exception) { throw new UnhandledException(exception); };
 
     default void onSubscribe(Subscription subscription) {};
 

--- a/src/main/java/org/ossgang/commons/observable/UnhandledException.java
+++ b/src/main/java/org/ossgang/commons/observable/UnhandledException.java
@@ -1,0 +1,11 @@
+package org.ossgang.commons.observable;
+
+/**
+ * An exception which is thrown by the default implementation of {@link Observer}, in case the onException() method has
+ * not been implemented. It will get dispatched to the global uncaught exception handler.
+ */
+public class UnhandledException extends RuntimeException {
+    UnhandledException(Throwable cause) {
+        super("Unhandled exception: " + cause.getClass().getSimpleName() + " : " + cause.getMessage(), cause);
+    }
+}

--- a/src/main/java/org/ossgang/commons/observable/UpdateDeliveryException.java
+++ b/src/main/java/org/ossgang/commons/observable/UpdateDeliveryException.java
@@ -1,0 +1,18 @@
+package org.ossgang.commons.observable;
+
+/**
+ * An exception wrapping any exception thrown by the onNext or onException methods of {@link Observer}. It also provides
+ * access to the value that failed to be dispatched through getValue().
+ */
+public class UpdateDeliveryException extends RuntimeException {
+    private final Object value;
+
+    UpdateDeliveryException(Object value, Throwable cause) {
+        super("Error delivering update : " + cause.getMessage() + "\n -> value: " + value, cause);
+        this.value = value;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+}

--- a/src/test/java/org/ossgang/commons/observable/UncaughtExceptionHandlerTest.java
+++ b/src/test/java/org/ossgang/commons/observable/UncaughtExceptionHandlerTest.java
@@ -1,0 +1,72 @@
+package org.ossgang.commons.observable;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.ossgang.commons.property.Properties;
+import org.ossgang.commons.property.Property;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UncaughtExceptionHandlerTest {
+
+    private final CompletableFuture<Throwable> exception = new CompletableFuture<>();
+
+    @Before
+    public void setUncaughtExceptionHandler() {
+        Observables.setUncaughtExceptionHandler(exception::complete);
+    }
+
+    @Test
+    public void subscriberThrows_shouldDeflect() throws Exception {
+        Property<String> property = Properties.property("A");
+        property.subscribe(v -> {
+            throw new RuntimeException("TEST-EXCEPTION");
+        });
+        property.set("b");
+
+        Throwable ex = exception.get(1, SECONDS);
+        assertThat(ex).isInstanceOf(UpdateDeliveryException.class).hasMessageContaining("TEST-EXCEPTION");
+        assertThat(((UpdateDeliveryException) ex).getValue()).isEqualTo("b");
+    }
+
+    @Test
+    public void mapThrows_subscriberDoesNotHandle_shouldDeflect() throws Exception {
+        Property<String> property = Properties.property("A");
+        property.map(Integer::valueOf).subscribe(System.out::println);
+        property.set("THIS-IS-NOT-A-NUMBER");
+
+        assertThat(exception.get(1, SECONDS))
+                .isInstanceOf(UnhandledException.class)
+                .hasMessageContaining("THIS-IS-NOT-A-NUMBER")
+                .hasCauseInstanceOf(NumberFormatException.class);
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void nothingThrows_shouldNotCatchAnything() throws Exception {
+        Property<String> property = Properties.property("A");
+        property.subscribe(System.out::println);
+        property.set("b");
+
+        exception.get(200, MILLISECONDS);
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void mapThrows_subscriberHandles_shouldNotDeflect() throws Exception {
+        TestObserver testObserver = new TestObserver();
+        Property<String> property = Properties.property("A");
+        property.map(Integer::valueOf).subscribe(testObserver);
+        property.set("THIS-IS-NOT-A-NUMBER");
+
+        exception.get(200, MILLISECONDS);
+        assertThat(testObserver.receivedExceptions()).hasSize(1);
+        assertThat((Exception) testObserver.receivedExceptions().get(0))
+                .isInstanceOf(UnhandledException.class)
+                .hasMessageContaining("THIS-IS-NOT-A-NUMBER")
+                .hasCauseInstanceOf(NumberFormatException.class);
+    }
+}


### PR DESCRIPTION
Fixes #13.

The idea is that Observers which do not implement onException "bounce back" the exceptions delivered to them, which then get intercepted in the dispatcher. The same happens if a handler genuinely throws an exception.

There can be a global exception handler which gets called in these cases, e.g. to log them using slf4j or any other logging framework the application uses. If unset, it defaults to the previous "print to stderr" behaviour.