### PR TITLE
add "event sources": Observable event dispatchers

### DIFF
--- a/src/main/java/org/ossgang/commons/event/EventSource.java
+++ b/src/main/java/org/ossgang/commons/event/EventSource.java
@@ -1,0 +1,11 @@
+package org.ossgang.commons.event;
+
+import org.ossgang.commons.observable.Observable;
+
+/**
+ * An "event source": an Observable-backed dispatcher for events of type T.
+ * @param <T>
+ */
+public interface EventSource<T> extends Observable<T> {
+    void send(T event);
+}

--- a/src/main/java/org/ossgang/commons/event/EventSources.java
+++ b/src/main/java/org/ossgang/commons/event/EventSources.java
@@ -1,0 +1,17 @@
+package org.ossgang.commons.event;
+
+public class EventSources {
+    private EventSources() {
+        throw new UnsupportedOperationException("static only");
+    }
+
+    /**
+     * Create a {@link EventSource}.
+     *
+     * @param <T> the type
+     * @return the new event source
+     */
+    public static <T> EventSource<T> eventSource() {
+        return new SimpleEventSource<>();
+    }
+}

--- a/src/main/java/org/ossgang/commons/event/SimpleEventSource.java
+++ b/src/main/java/org/ossgang/commons/event/SimpleEventSource.java
@@ -1,0 +1,12 @@
+package org.ossgang.commons.event;
+
+import org.ossgang.commons.observable.DispatchingObservable;
+
+public class SimpleEventSource<T> extends DispatchingObservable<T> implements EventSource<T>  {
+    SimpleEventSource() {}
+
+    @Override
+    public void send(T event) {
+        dispatchValue(event);
+    }
+}

--- a/src/main/java/org/ossgang/commons/observable/Observable.java
+++ b/src/main/java/org/ossgang/commons/observable/Observable.java
@@ -22,6 +22,12 @@
 
 package org.ossgang.commons.observable;
 
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.ossgang.commons.observable.DerivedObservableValue.derive;
+
 /**
  * An stream of objects of type T, which can be subscribed to by interested consumers.
  *
@@ -44,4 +50,26 @@ public interface Observable<T> {
      * @return a Subscription object, which can be used to unsubscribe at a later point
      */
     Subscription subscribe(Observer<? super T> listener, SubscriptionOption... options);
+
+    /**
+     * Create a derived observable applying a mapping function to each value.
+     *
+     * @param mapper the mapper to apply
+     * @param <D> the destination type
+     * @return the derived observable
+     */
+    default <D> Observable<D> map(Function<T, D> mapper) {
+        return derive(this, mapper.andThen(Optional::of));
+    }
+
+    /**
+     * Create a derived observable applying a filtering function to the updates of this one. Values which do not
+     * match the provided predicate are discarded.
+     *
+     * @param filter the filter to apply
+     * @return the derived observable
+     */
+    default Observable<T> filter(Predicate<T> filter) {
+        return derive(this, v -> Optional.of(v).filter(filter));
+    }
 }

--- a/src/main/java/org/ossgang/commons/observable/Observables.java
+++ b/src/main/java/org/ossgang/commons/observable/Observables.java
@@ -59,7 +59,7 @@ public class Observables {
      * @return an {@link ObservableValue} that zips the values of the provided {@link ObservableValue}. The {@link Map}
      * parameter provides the indexes of the {@link Map} that will be passed to the specified mapper {@link Function}.
      */
-    public static <K, I, O> ObservableValue<O> zip(Map<K, ObservableValue<I>> sourcesMap, Function<Map<K, I>, O> combiner) {
+    public static <K, I, O> ObservableValue<O> zip(Map<K, ? extends Observable<I>> sourcesMap, Function<Map<K, I>, O> combiner) {
         Map<K, I> valueMap = new HashMap<>();
         Set<K> keys = new HashSet<>(sourcesMap.keySet());
         return derive(sourcesMap, (k, v) -> {
@@ -90,7 +90,7 @@ public class Observables {
      * the provided {@link ObservableValue} matches the index of the {@link List} of values provided to the mapping
      * {@link Function}.
      */
-    public static <I, O> ObservableValue<O> zip(List<ObservableValue<I>> sources, Function<List<I>, O> combiner) {
+    public static <I, O> ObservableValue<O> zip(List<? extends Observable<I>> sources, Function<List<I>, O> combiner) {
         return zip(toIndexMap(sources), idxMap -> combiner.apply(fromIndexMap(idxMap)));
     }
 
@@ -107,7 +107,7 @@ public class Observables {
      * @return an {@link ObservableValue} that zips the values of the provided {@link ObservableValue}. The {@link Map} parameter provides the indexes of the
      * resulting {@link ObservableValue} values.
      */
-    public static <K, I> ObservableValue<Map<K, I>> zip(Map<K, ObservableValue<I>> sourcesMap) {
+    public static <K, I> ObservableValue<Map<K, I>> zip(Map<K, ? extends Observable<I>> sourcesMap) {
         return zip(sourcesMap, Function.identity());
     }
 
@@ -122,7 +122,7 @@ public class Observables {
      * @return an {@link ObservableValue} that zips the values of the provided {@link ObservableValue}. The index of
      * the provided {@link ObservableValue} matches the index of the {@link List} in the resulting {@link ObservableValue}.
      */
-    public static <I> ObservableValue<List<I>> zip(List<ObservableValue<I>> sources) {
+    public static <I> ObservableValue<List<I>> zip(List<? extends Observable<I>> sources) {
         return zip(sources, Function.identity());
     }
 
@@ -138,7 +138,7 @@ public class Observables {
      * @return an {@link ObservableValue} that on each update of any source {@link ObservableValue} publishes the
      * result of applying the mapper {@link Function}. The {@link Map}s are used to avoid mathing values by index.
      */
-    public static <K, I, O> ObservableValue<O> combineLatest(Map<K, ObservableValue<I>> sourcesMap,
+    public static <K, I, O> ObservableValue<O> combineLatest(Map<K, ? extends Observable<I>> sourcesMap,
                                                              Function<Map<K, I>, O> combiner) {
         Map<K, I> valueMap = new HashMap<>();
         Set<K> keys = new HashSet<>(sourcesMap.keySet());
@@ -165,7 +165,7 @@ public class Observables {
      * @return an {@link ObservableValue} that on each update of any source publishes the result of the
      * combiner applied with the latest values of the other inputs.
      */
-    public static <I, O> ObservableValue<O> combineLatest(List<ObservableValue<I>> sources,
+    public static <I, O> ObservableValue<O> combineLatest(List<? extends Observable<I>> sources,
                                                           Function<List<I>, O> combiner) {
         return combineLatest(toIndexMap(sources), idxMap -> combiner.apply(fromIndexMap(idxMap)));
     }
@@ -180,7 +180,7 @@ public class Observables {
      * @return an {@link ObservableValue} that on each update of any source {@link ObservableValue} publishes a
      * {@link Map} with the values of each corresponding source {@link ObservableValue}.
      */
-    public static <K, I> ObservableValue<Map<K, I>> combineLatest(Map<K, ObservableValue<I>> sourcesMap) {
+    public static <K, I> ObservableValue<Map<K, I>> combineLatest(Map<K, ? extends Observable<I>> sourcesMap) {
         return combineLatest(sourcesMap, Function.identity());
     }
 
@@ -193,7 +193,7 @@ public class Observables {
      * @return an {@link ObservableValue} that on each update of any source {@link ObservableValue} publishes the
      * a list containing the values of each {@link ObservableValue}
      */
-    public static <I> ObservableValue<List<I>> combineLatest(List<ObservableValue<I>> sources) {
+    public static <I> ObservableValue<List<I>> combineLatest(List<? extends Observable<I>> sources) {
         return combineLatest(sources, Function.identity());
     }
 

--- a/src/test/java/org/ossgang/commons/event/SimpleEventSourceTest.java
+++ b/src/test/java/org/ossgang/commons/event/SimpleEventSourceTest.java
@@ -1,0 +1,34 @@
+package org.ossgang.commons.event;
+
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ossgang.commons.event.EventSources.eventSource;
+
+public class SimpleEventSourceTest {
+
+    @Test
+    public void isDispatching() throws Exception {
+        CompletableFuture<Integer> subscriber1 = new CompletableFuture<>();
+        CompletableFuture<Integer> subscriber2 = new CompletableFuture<>();
+        CompletableFuture<Integer> subscriber3 = new CompletableFuture<>();
+        EventSource<Integer> eventSource = eventSource();
+        eventSource.subscribe(subscriber1::complete);
+        eventSource.subscribe(subscriber2::complete);
+        eventSource.subscribe(subscriber3::complete);
+        assertThat(subscriber1.isDone()).isFalse();
+        assertThat(subscriber2.isDone()).isFalse();
+        assertThat(subscriber3.isDone()).isFalse();
+
+        eventSource.send(42);
+
+        assertThat(subscriber1.get(1, TimeUnit.SECONDS)).isEqualTo(42);
+        assertThat(subscriber2.get(1, TimeUnit.SECONDS)).isEqualTo(42);
+        assertThat(subscriber3.get(1, TimeUnit.SECONDS)).isEqualTo(42);
+
+    }
+
+}


### PR DESCRIPTION
Hi,

In some cases it may be useful to just use the dispatching (and possible mapping, ...) logic of Observable for distributing e.g. events.

Obviously, this could be done with Property as well (even though keeping the latest value will usually not be required in this case), but to make intensions clear, I propose to have another set of "leaf" classes aside Property - I called them "EventSource".

An EventSource simply implements Observable and provides a public method to send events downstream.

In the same going, I also made sure that map/filter are available for Observable interface as well.