### PR TITLE
Add ConstantExceptionObservableValue

### DIFF
--- a/src/main/java/org/ossgang/commons/observables/ConstantExceptionObservableValue.java
+++ b/src/main/java/org/ossgang/commons/observables/ConstantExceptionObservableValue.java
@@ -1,0 +1,34 @@
+package org.ossgang.commons.observables;
+
+import org.ossgang.commons.observables.exceptions.UnhandledException;
+
+import static org.ossgang.commons.observables.ExceptionHandlers.dispatchToUncaughtExceptionHandler;
+
+/**
+ * An immutable implementation of {@link ObservableValue} which always returns null on get(),
+ * and immediately dispatches a constant exception as a single update on subscribe().
+ *
+ * @param <T> any type for compatibility with ObservableValue
+ */
+public final class ConstantExceptionObservableValue<T> implements ObservableValue<T> {
+    private final Throwable throwable;
+
+    ConstantExceptionObservableValue(Throwable throwable) {
+        this.throwable = throwable;
+    }
+
+    @Override
+    public T get() {
+        return null;
+    }
+
+    @Override
+    public Subscription subscribe(Observer<? super T> listener, SubscriptionOption... options) {
+        try {
+            listener.onException(throwable);
+        } catch (UnhandledException e) {
+            dispatchToUncaughtExceptionHandler(e);
+        }
+        return () -> {};
+    }
+}

--- a/src/main/java/org/ossgang/commons/observables/ConstantObservableValue.java
+++ b/src/main/java/org/ossgang/commons/observables/ConstantObservableValue.java
@@ -1,5 +1,9 @@
 package org.ossgang.commons.observables;
 
+import org.ossgang.commons.observables.exceptions.UpdateDeliveryException;
+
+import static org.ossgang.commons.observables.ExceptionHandlers.dispatchToUncaughtExceptionHandler;
+
 /**
  * A fixed-value, immutable implementation of {@link ObservableValue}. Such an observable always returns the same
  * constant value on get(), and immediately dispatches one single update on subscribe().
@@ -20,7 +24,11 @@ public final class ConstantObservableValue<T> implements ObservableValue<T> {
 
     @Override
     public Subscription subscribe(Observer<? super T> listener, SubscriptionOption... options) {
-        listener.onValue(value);
+        try {
+            listener.onValue(value);
+        } catch (Exception e) {
+            dispatchToUncaughtExceptionHandler(new UpdateDeliveryException(value, e));
+        }
         return () -> {};
     }
 }

--- a/src/main/java/org/ossgang/commons/observables/DispatchingObservable.java
+++ b/src/main/java/org/ossgang/commons/observables/DispatchingObservable.java
@@ -25,7 +25,10 @@ package org.ossgang.commons.observables;
 import org.ossgang.commons.observables.exceptions.UnhandledException;
 import org.ossgang.commons.observables.exceptions.UpdateDeliveryException;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -34,6 +37,7 @@ import java.util.function.Predicate;
 
 import static java.util.Collections.newSetFromMap;
 import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.ossgang.commons.observables.ExceptionHandlers.dispatchToUncaughtExceptionHandler;
 
 /**
  * A basic implementation of {@link Observable} managing a set of listeners, and dispatching updates to them.
@@ -49,7 +53,6 @@ public class DispatchingObservable<T> implements Observable<T> {
     private static final ExecutorService DISPATCHER_POOL = newCachedThreadPool(new DispatchingThreadFactory());
     private final Map<Observer<? super T>, ObservableSubscription> listeners = new ConcurrentHashMap<>();
     private final AtomicInteger listenerCount = new AtomicInteger(0);
-    private static Consumer<Exception> uncaughtExceptionHandler = DispatchingObservable::printExceptionToStderr;
 
     protected DispatchingObservable() {
     }
@@ -118,24 +121,6 @@ public class DispatchingObservable<T> implements Observable<T> {
         });
     }
 
-    private static void dispatchToUncaughtExceptionHandler(Exception exception) {
-        try {
-            uncaughtExceptionHandler.accept(exception);
-        } catch (Exception e) {
-            System.err.println("[Observable] An exception occurred in the global uncaught exception handler.");
-            exception.printStackTrace();
-        }
-    }
-
-    private static void printExceptionToStderr(Exception exception) {
-        System.err.println("[Observable] An unhandled exception occurred.");
-        exception.printStackTrace();
-    }
-
-    static void setUncaughtExceptionHandler(Consumer<Exception> handler) {
-        Objects.requireNonNull(handler, "The exception handler must not be null");
-        uncaughtExceptionHandler = handler;
-    }
 
     private class ObservableSubscription implements Subscription {
         private final Observer<? super T> listener;

--- a/src/main/java/org/ossgang/commons/observables/ExceptionHandlers.java
+++ b/src/main/java/org/ossgang/commons/observables/ExceptionHandlers.java
@@ -1,0 +1,31 @@
+package org.ossgang.commons.observables;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+final class ExceptionHandlers {
+    private static volatile Consumer<Exception> uncaughtExceptionHandler = ExceptionHandlers::printExceptionToStderr;
+
+    private ExceptionHandlers() {
+        throw new UnsupportedOperationException("static only");
+    }
+
+    static void dispatchToUncaughtExceptionHandler(Exception exception) {
+        try {
+            uncaughtExceptionHandler.accept(exception);
+        } catch (Exception e) {
+            System.err.println("[Observable] An exception occurred in the global uncaught exception handler.");
+            exception.printStackTrace();
+        }
+    }
+
+    private static void printExceptionToStderr(Exception exception) {
+        System.err.println("[Observable] An unhandled exception occurred.");
+        exception.printStackTrace();
+    }
+
+    static void setUncaughtExceptionHandler(Consumer<Exception> handler) {
+        Objects.requireNonNull(handler, "The exception handler must not be null");
+        uncaughtExceptionHandler = handler;
+    }
+}

--- a/src/main/java/org/ossgang/commons/observables/Observables.java
+++ b/src/main/java/org/ossgang/commons/observables/Observables.java
@@ -91,6 +91,18 @@ public final class Observables {
     }
 
     /**
+     * Create a constant {@link ObservableValue} holding an exception. This observable is immutable, will always return
+     * null on get(), and it will immediately send the exception to the consumer on subscribe().
+     *
+     * @param throwable the exception to throw
+     * @param <T>   any type, to be compatible with any ObservableValue signature
+     * @return a constant ObservableValue
+     */
+    public static <T> ObservableValue<T> constantException(Throwable throwable) {
+        return new ConstantExceptionObservableValue<>(throwable);
+    }
+
+    /**
      * Create an {@link ObservableValue} from any {@link Observable}. If the observable passed in is an instance of
      * {@link ObservableValue}, it is returned unchanged. Otherwise, a derived observable value is created which
      * subscribes to the upstream observable and caches its latest value.
@@ -246,7 +258,7 @@ public final class Observables {
      * @see UnhandledException
      */
     public static void setUncaughtExceptionHandler(Consumer<Exception> handler) {
-        DispatchingObservable.setUncaughtExceptionHandler(handler);
+        ExceptionHandlers.setUncaughtExceptionHandler(handler);
     }
 
 }

--- a/src/test/java/org/ossgang/commons/observables/ConstantExceptionObservableValueTest.java
+++ b/src/test/java/org/ossgang/commons/observables/ConstantExceptionObservableValueTest.java
@@ -1,0 +1,42 @@
+package org.ossgang.commons.observables;
+
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ossgang.commons.observables.Observers.withErrorHandling;
+
+public class ConstantExceptionObservableValueTest {
+    @Test
+    public void getReturnsNull() {
+        ConstantExceptionObservableValue<Object> exceptionObservableValue =
+                new ConstantExceptionObservableValue<>(new RuntimeException("fail"));
+        assertThat(exceptionObservableValue.get()).isNull();
+    }
+
+    @Test
+    public void subscribeForwardsExceptionToSubscriber() throws InterruptedException, ExecutionException, TimeoutException {
+        RuntimeException anyException = new RuntimeException("fail");
+        ConstantExceptionObservableValue<Object> exceptionObservableValue =
+                new ConstantExceptionObservableValue<>(anyException);
+        CompletableFuture<Object> valueUpdate = new CompletableFuture<>();
+        CompletableFuture<Throwable> exceptionUpdate = new CompletableFuture<>();
+        exceptionObservableValue.subscribe(withErrorHandling(valueUpdate::complete, exceptionUpdate::complete));
+        assertThat(exceptionUpdate.get(1, SECONDS)).isSameAs(anyException);
+        assertThat(valueUpdate.isDone()).isFalse();
+    }
+
+    @Test
+    public void unhandledExceptionFromConsumerDoesNotLeak() {
+        RuntimeException anyException = new RuntimeException("fail");
+        ConstantExceptionObservableValue<Object> exceptionObservableValue =
+                new ConstantExceptionObservableValue<>(anyException);
+
+        exceptionObservableValue.subscribe(e -> {});
+    }
+
+}

--- a/src/test/java/org/ossgang/commons/observables/ConstantObservableValueTest.java
+++ b/src/test/java/org/ossgang/commons/observables/ConstantObservableValueTest.java
@@ -1,0 +1,34 @@
+package org.ossgang.commons.observables;
+
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConstantObservableValueTest {
+
+    @Test
+    public void valueIsProvided() throws InterruptedException, ExecutionException, TimeoutException {
+        Object anyObject = new Object();
+        ConstantObservableValue<Object> constantObservable = new ConstantObservableValue<>(anyObject);
+        assertThat(constantObservable.get()).isSameAs(anyObject);
+        CompletableFuture<Object> valueFromSubscription = new CompletableFuture<>();
+        constantObservable.subscribe(valueFromSubscription::complete);
+        assertThat(valueFromSubscription.get(1, TimeUnit.SECONDS)).isSameAs(anyObject);
+    }
+
+    @Test
+    public void exceptionInConsumerDoesNotLeak() {
+        Object anyObject = new Object();
+        ConstantObservableValue<Object> constantObservable = new ConstantObservableValue<>(anyObject);
+
+        constantObservable.subscribe(e -> {
+            throw new RuntimeException("fail");
+        });
+    }
+
+}

--- a/src/test/java/org/ossgang/commons/observables/ExceptionHandlersTest.java
+++ b/src/test/java/org/ossgang/commons/observables/ExceptionHandlersTest.java
@@ -15,7 +15,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class UncaughtExceptionHandlerTest {
+public class ExceptionHandlersTest {
 
     private final CompletableFuture<Throwable> exception = new CompletableFuture<>();
 


### PR DESCRIPTION
In some cases (in particular when mass-creating observables, and one of them fails), it can be useful to create an observable which contains a constant exception. This is implemented by the new ConstantExceptionObservableValue.

Furthermore, this change set extracts the management of the global uncaught exception handler from DispatchingObservable into it's own class, in order to re-use it in other places.