### PR TITLE
add awaitNext() functionality on Observable

### DIFF
--- a/src/main/java/org/ossgang/commons/awaitables/Retry.java
+++ b/src/main/java/org/ossgang/commons/awaitables/Retry.java
@@ -94,7 +94,11 @@ public class Retry<T> extends BaseAwaitable<T, Retry<T>> {
         }
 
         public Retry<T> until(Predicate<T> predicate) {
-            return retryUntil(() -> Optional.of(supplier.get()).filter(predicate));
+            return retryUntil(() -> Optional.ofNullable(supplier.get()).filter(predicate));
+        }
+
+        public Retry<T> untilNotNull() {
+            return retryUntil(() -> Optional.ofNullable(supplier.get()));
         }
     }
 }

--- a/src/main/java/org/ossgang/commons/observables/Observable.java
+++ b/src/main/java/org/ossgang/commons/observables/Observable.java
@@ -23,8 +23,11 @@
 package org.ossgang.commons.observables;
 
 
+import org.ossgang.commons.monads.Maybe;
+import org.ossgang.commons.observables.operators.BlockingOperators;
 import org.ossgang.commons.observables.operators.DerivedObservableValue;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -81,5 +84,30 @@ public interface Observable<T> {
      */
     default <D> Observable<D> derive(Function<T, Optional<D>> mapper) {
         return DerivedObservableValue.derive(this, mapper);
+    }
+
+    /**
+     * Blocks and awaits the next update on this observable (which can be either a value or an exception), and returns
+     * it as a Maybe&lt;T&gt;. Note that while an exception-update on this observable will be wrapped in a Maybe, this
+     * method throws an AwaitTimeoutException in case the timeout exceeds.
+     *
+     * @param timeout the timeout for the wait
+     * @throws org.ossgang.commons.awaitables.exceptions.AwaitTimeoutException if the timeout is exceeded
+     * @return a Maybe&lt;T&gt; containing either the value or the exception from the next update on this observable
+     */
+    default Maybe<T> awaitNext(Duration timeout) {
+        return BlockingOperators.awaitNext(this, timeout);
+    }
+
+    /**
+     * Blocks and awaits the next value-update on this observable. Any exception-updates are ignored. If no value is
+     * received until the timeout passes, this method throws an AwaitTimeoutException.
+     *
+     * @param timeout the timeout for the wait
+     * @throws org.ossgang.commons.awaitables.exceptions.AwaitTimeoutException if the timeout is exceeded
+     * @return the next value on this observable
+     */
+    default T awaitNextValue(Duration timeout) {
+        return BlockingOperators.awaitNextValue(this, timeout);
     }
 }

--- a/src/main/java/org/ossgang/commons/observables/operators/BlockingOperators.java
+++ b/src/main/java/org/ossgang/commons/observables/operators/BlockingOperators.java
@@ -1,0 +1,39 @@
+package org.ossgang.commons.observables.operators;
+
+import org.ossgang.commons.monads.Maybe;
+import org.ossgang.commons.observables.Observable;
+import org.ossgang.commons.observables.Observer;
+import org.ossgang.commons.observables.Observers;
+import org.ossgang.commons.observables.Subscription;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static org.ossgang.commons.awaitables.Retry.retry;
+
+public final class BlockingOperators {
+    private BlockingOperators() {
+        throw new UnsupportedOperationException("static only");
+    }
+
+    public static <T> T awaitNextValue(Observable<T> observable, Duration timeout) {
+        return awaitNextItem(observable, timeout, consumer -> consumer::accept);
+    }
+
+    public static <T> Maybe<T> awaitNext(Observable<T> observable, Duration timeout) {
+        return awaitNextItem(observable, timeout, Observers::forMaybes);
+    }
+
+    private static <T, O> T awaitNextItem(Observable<O> observable, Duration timeout,
+                                          Function<Consumer<T>, Observer<O>> observerFactory) {
+        AtomicReference<T> update = new AtomicReference<>();
+        Subscription subscription = observable.subscribe(observerFactory.apply(update::set));
+        try {
+            return retry(update::get).untilNotNull().atMost(timeout);
+        } finally {
+            subscription.unsubscribe();
+        }
+    }
+}

--- a/src/test/java/org/ossgang/commons/observables/operators/BlockingOperatorsTest.java
+++ b/src/test/java/org/ossgang/commons/observables/operators/BlockingOperatorsTest.java
@@ -1,0 +1,78 @@
+package org.ossgang.commons.observables.operators;
+
+import org.junit.Test;
+import org.ossgang.commons.awaitables.exceptions.AwaitTimeoutException;
+import org.ossgang.commons.monads.Maybe;
+import org.ossgang.commons.observables.Dispatcher;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.ossgang.commons.monads.Maybe.attempt;
+import static org.ossgang.commons.observables.Observables.dispatcher;
+
+public class BlockingOperatorsTest {
+    public static final Duration TIMEOUT = Duration.ofSeconds(10);
+    public static final Duration REACHABLE_TIMEOUT = Duration.ofMillis(100);
+    private Dispatcher<String> observable = dispatcher("initial");
+
+    @Test
+    public void awaitNextValue_shouldIgnoreExceptionsAndReturnNextValue() {
+        CompletableFuture<String> nextValue = supplyAsync(() -> observable.awaitNextValue(TIMEOUT));
+        waitForCompletableFuture();
+        observable.dispatchException(new Exception("some exception"));
+        observable.dispatchException(new Exception("another exception"));
+        assertThat(nextValue.isDone()).isFalse();
+        String dispatchedUpdate = "UPDATE";
+        observable.dispatchValue(dispatchedUpdate);
+        assertThat(nextValue.join()).isEqualTo(dispatchedUpdate);
+    }
+
+    @Test
+    public void awaitNext_nextUpdateIsException_shouldReturnException() {
+        CompletableFuture<Maybe<String>> nextValue = supplyAsync(() -> observable.awaitNext(TIMEOUT));
+        waitForCompletableFuture();
+        Exception dispatchedException = new Exception("some exception");
+        observable.dispatchException(dispatchedException);
+        assertThat(nextValue.join().exception()).isEqualTo(dispatchedException);
+    }
+
+    @Test
+    public void awaitNext_nextUpdateIsValue_shouldReturnValue() {
+        CompletableFuture<Maybe<String>> nextValue = supplyAsync(() -> observable.awaitNext(TIMEOUT));
+        waitForCompletableFuture();
+        String dispatchedUpdate = "UPDATE";
+        observable.dispatchValue(dispatchedUpdate);
+        assertThat(nextValue.join().value()).isEqualTo(dispatchedUpdate);
+    }
+
+    @Test
+    public void awaitNextValue_noValueUpdateWithinTimeout_shouldThrow() {
+        CompletableFuture<String> nextValue = supplyAsync(() -> observable.awaitNextValue(REACHABLE_TIMEOUT));
+        waitForCompletableFuture();
+        observable.dispatchException(new Exception("some exception"));
+        observable.dispatchException(new Exception("another exception"));
+        assertThat(nextValue.isDone()).isFalse();
+        assertThatExceptionOfType(CompletionException.class).isThrownBy(nextValue::join)
+                .withCauseExactlyInstanceOf(AwaitTimeoutException.class)
+                .withMessageContaining("Timeout exceeded");
+    }
+
+    @Test
+    public void awaitNext_noUpdateWithinTimeout_shouldThrow() {
+        CompletableFuture<Maybe<String>> nextValue = supplyAsync(() -> observable.awaitNext(REACHABLE_TIMEOUT));
+        waitForCompletableFuture();
+        assertThatExceptionOfType(CompletionException.class).isThrownBy(nextValue::join)
+                .withCauseExactlyInstanceOf(AwaitTimeoutException.class)
+                .withMessageContaining("Timeout exceeded");
+    }
+
+    private void waitForCompletableFuture() {
+        attempt(() -> MILLISECONDS.sleep(50)).throwOnException();
+    }
+}


### PR DESCRIPTION
add blocking operations to retrieve the next value to Observable:
-  `awaitNext()` returns a Maybe if either an exception or a value is delivered on the observable
-  `awaitNextValue()` waits until an actual value (no exception) is dispatched

Both re-use existing functionality of the awaitables package to perform the waits.