### PR TITLE
OSGi support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,8 @@ jar {
     // OSGi
     bnd([
         'Bundle-Vendor': 'CERN',
-        'Export-Package': '*'
+        'Export-Package': '*',
+        'Import-Package': '' // no dependencies
     ])
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -137,4 +137,6 @@ if (project['DEPLOYMENT']) {
     apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.bintray'
     apply from: 'https://raw.githubusercontent.com/ossgang/gradle-scripts/master/deployment/bintray-deploy.gradle'
+
+    version = project.ext.getDeploymentVersion()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
         if (project['CERN_VM']) {
             maven { url 'http://artifactory.cern.ch/ds-jcenter' }
             maven { url 'http://artifactory.cern.ch/development' }
+            maven { url 'http://artifactory.cern.ch/gradle-plugins' }
         } else {
             maven { url 'https://plugins.gradle.org/m2/' }
             jcenter()
@@ -22,6 +23,8 @@ buildscript {
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.jk1:gradle-license-report:1.5'
+        classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:4.3.1' // OSGi
+        classpath 'biz.aQute.bnd:biz.aQute.bndlib:4.3.1' // OSGi
     }
 }
 
@@ -29,6 +32,7 @@ apply plugin: 'java'
 apply plugin: 'jacoco'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
+apply plugin: 'biz.aQute.bnd.builder' // OSGi
 
 group = project['POM.groupId']
 
@@ -57,6 +61,14 @@ sourceSets {
     main {
         resources { srcDirs = ['src/main/java'] }
     }
+}
+
+jar {
+    // OSGi
+    bnd([
+        'Bundle-Vendor': 'CERN',
+        'Export-Package': '*'
+    ])
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ sourceSets {
 jar {
     // OSGi
     bnd([
-        'Bundle-Vendor': 'CERN',
+        'Bundle-Vendor': 'ossgang',
         'Export-Package': '*',
         'Import-Package': '' // no dependencies
     ])


### PR DESCRIPTION
I have added OSGi support - this basically means extra entries in MANIFEST.MF. As the project has no external dependencies, it is straightforward and the Bnd Gradle Plugin takes care of everything with minimal configuration.

However, I could not test whether the version is properly applied (I suppose it comes from the CI server). To check it, someone needs to build the JAR and look in MANIFEST.MF.

The manifest generated on my machine looks like this:

```
Manifest-Version: 1.0
Bnd-LastModified: 1589904947042
Bundle-ManifestVersion: 2
Bundle-Name: ossgang-commons
Bundle-SymbolicName: ossgang-commons
Bundle-Vendor: CERN
Bundle-Version: 0.0.0
Created-By: 1.8.0_252 (AdoptOpenJDK)
Export-Package: org.ossgang.commons.awaitables;version="0.0.0",org.oss
 gang.commons.awaitables.exceptions;version="0.0.0",org.ossgang.common
 s.collections;version="0.0.0",org.ossgang.commons.mapbackeds;version=
 "0.0.0",org.ossgang.commons.monads;version="0.0.0",org.ossgang.common
 s.observables;uses:="org.ossgang.commons.monads,org.ossgang.commons.o
 bservables.operators.connectors";version="0.0.0",org.ossgang.commons.
 observables.exceptions;version="0.0.0",org.ossgang.commons.observable
 s.operators;uses:="org.ossgang.commons.monads,org.ossgang.commons.obs
 ervables";version="0.0.0",org.ossgang.commons.observables.operators.b
 uffer;uses:="org.ossgang.commons.observables,org.ossgang.commons.prop
 erties";version="0.0.0",org.ossgang.commons.observables.operators.con
 nectors;uses:="org.ossgang.commons.observables,org.ossgang.commons.pr
 operties";version="0.0.0",org.ossgang.commons.observables.testing;use
 s:="org.ossgang.commons.observables";version="0.0.0",org.ossgang.comm
 ons.observables.weak;uses:="org.ossgang.commons.observables";version=
 "0.0.0",org.ossgang.commons.properties;uses:="org.ossgang.commons.obs
 ervables";version="0.0.0",org.ossgang.commons.utils;uses:="org.ossgan
 g.commons.monads";version="0.0.0"
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
Tool: Bnd-4.3.1.201911131708
```

For a released version, it shall contain the real version instead of "0.0.0" at all places. According to docs and my former experience, this should work out of the box.

