### PR TITLE
AsyncMaybe<Void> fail with some operators

### DIFF
--- a/src/main/java/org/ossgang/commons/monads/AsyncMaybe.java
+++ b/src/main/java/org/ossgang/commons/monads/AsyncMaybe.java
@@ -1,9 +1,6 @@
-// @formatter:off
-/*******************************************************************************
- *
- * This file is part of ossgang-commons.
- *
- * Copyright (c) 2008-2019, CERN. All rights reserved.
+/*
+ * @formatter:off
+ * Copyright (c) 2008-2020, CERN. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +13,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- ******************************************************************************/
-// @formatter:on
+ * @formatter:on
+ */
 
 package org.ossgang.commons.monads;
 
@@ -64,7 +60,7 @@ public class AsyncMaybe<T> {
      * @return An {@link AsyncMaybe} wrapping the execution of the provided runnable
      */
     public static AsyncMaybe<Void> attemptAsync(ThrowingRunnable runnable) {
-        requireNonNull(runnable, "Runnable cannot be null");
+        requireNonNull(runnable, "AsyncMaybe runnable cannot be null");
         return new AsyncMaybe<>(supplyAsync(() -> Maybe.attempt(() -> uncheckedRunnable(runnable).run()), ASYNC_MAYBE_POOL));
     }
 
@@ -76,7 +72,7 @@ public class AsyncMaybe<T> {
      * @return An {@link AsyncMaybe} wrapping the execution of the provided supplier
      */
     public static <T> AsyncMaybe<T> attemptAsync(ThrowingSupplier<T> supplier) {
-        requireNonNull(supplier, "Value supplier cannot be null");
+        requireNonNull(supplier, "AsyncMaybe value supplier cannot be null");
         return new AsyncMaybe<>(supplyAsync(() -> Maybe.attempt(() -> requireNonNullResult(supplier).get()), ASYNC_MAYBE_POOL));
     }
 
@@ -128,6 +124,7 @@ public class AsyncMaybe<T> {
      * @return a new {@link AsyncMaybe} with the same result as this {@link AsyncMaybe} or with an exception if one is thrown in the provided consumer
      */
     public AsyncMaybe<T> whenValue(ThrowingConsumer<T> consumer) {
+        requireNonNull(consumer, "Value consumer cannot be null");
         return new AsyncMaybe<>(stage.thenApplyAsync(stageResult -> stageResult.ifValue(uncheckedConsumer(consumer)), ASYNC_MAYBE_POOL));
     }
 
@@ -141,6 +138,7 @@ public class AsyncMaybe<T> {
      * @return a new {@link AsyncMaybe} with the same result as this {@link AsyncMaybe} or with an exception if one thrown in the provided consumer
      */
     public AsyncMaybe<T> whenComplete(ThrowingConsumer<Maybe<T>> consumer) {
+        requireNonNull(consumer, "Consumer cannot be null");
         return new AsyncMaybe<>(stage.thenApplyAsync(stageResult ->
                 Maybe.attempt(() -> consumer.accept(stageResult)).flatMap(any -> stageResult), ASYNC_MAYBE_POOL));
     }
@@ -157,6 +155,7 @@ public class AsyncMaybe<T> {
      * @return a new {@link AsyncMaybe} with the same result as this {@link AsyncMaybe} or with an exception if one is thrown in the provided consumer
      */
     public AsyncMaybe<T> whenComplete(BiConsumer<T, Throwable> consumer) {
+        requireNonNull(consumer, "Consumer cannot be null");
         return new AsyncMaybe<>(stage.thenApplyAsync(stageResult -> stageResult
                 .ifValue(v -> consumer.accept(v, null))
                 .ifException(e -> consumer.accept(null, e)), ASYNC_MAYBE_POOL));
@@ -172,6 +171,7 @@ public class AsyncMaybe<T> {
      * @return a new {@link AsyncMaybe} with the same result as this {@link AsyncMaybe} or with an exception if one is thrown in the provided consumer
      */
     public AsyncMaybe<T> whenException(ThrowingConsumer<Throwable> consumer) {
+        requireNonNull(consumer, "Exception consumer cannot be null");
         return new AsyncMaybe<>(stage.thenApplyAsync(stageResult -> stageResult.ifException(uncheckedConsumer(consumer)), ASYNC_MAYBE_POOL));
     }
 

--- a/src/main/java/org/ossgang/commons/monads/Maybe.java
+++ b/src/main/java/org/ossgang/commons/monads/Maybe.java
@@ -246,7 +246,7 @@ public class Maybe<T> {
      * @param function the function to apply
      * @return A successful Maybe the new value if the transformation succeeds. An unsuccessful Maybe otherwise.
      */
-    public <R> Maybe<R> flatMap(Function<T, Maybe<R>> function) {
+    public <R> Maybe<R> flatMap(ThrowingFunction<T, Maybe<R>> function) {
         requireNonNull(function);
         if (exception != null) {
             return Maybe.ofException(exception);

--- a/src/test/java/org/ossgang/commons/monads/AsyncMaybeTest.java
+++ b/src/test/java/org/ossgang/commons/monads/AsyncMaybeTest.java
@@ -84,6 +84,7 @@ public class AsyncMaybeTest {
                 .map((Integer v) -> assertThat(v).isEqualTo(-21))//
                 .then(() -> "Success")
                 .toMaybeBlocking();
+        chain.throwOnException();
         assertThat(chain.value()).isEqualTo("Success");
     }
 

--- a/src/test/java/org/ossgang/commons/monads/AsyncMaybeTest.java
+++ b/src/test/java/org/ossgang/commons/monads/AsyncMaybeTest.java
@@ -23,13 +23,11 @@
 package org.ossgang.commons.monads;
 
 import org.junit.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.time.Duration;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
@@ -96,7 +94,7 @@ public class AsyncMaybeTest {
                 .map(this::throwException2)
                 .toMaybeBlocking();
         assertThat(maybe.hasException()).isTrue();
-        assertThat(maybe.exception()).hasCauseInstanceOf(MaybeTestException1.class);
+        assertThat(maybe.exception()).isInstanceOf(MaybeTestException1.class);
         maybe.value(); /* <- throws */
     }
 
@@ -114,7 +112,7 @@ public class AsyncMaybeTest {
         verify(function1, times(1)).apply("HelloWorld");
         verify(function2, never()).apply(anyInt());
         assertThat(maybe.hasException()).isTrue();
-        assertThat(maybe.exception()).hasCauseInstanceOf(MaybeTestException2.class);
+        assertThat(maybe.exception()).isInstanceOf(MaybeTestException2.class);
     }
 
     @Test
@@ -146,7 +144,7 @@ public class AsyncMaybeTest {
         Mockito.when(function1.apply(anyString())).thenReturn("42");
 
         ThrowingFunction<Throwable, Integer> recoveryFunction = mock(ThrowingFunction.class);
-        Mockito.when(recoveryFunction.apply(anyExceptionWithCause(MaybeTestException2.class))).thenReturn(42);
+        Mockito.when(recoveryFunction.apply(any(MaybeTestException2.class))).thenReturn(42);
 
         ThrowingFunction<Integer, String> function2 = mock(ThrowingFunction.class);
         Mockito.when(function2.apply(42)).thenReturn("OK");
@@ -158,7 +156,7 @@ public class AsyncMaybeTest {
                 .map(function2)
                 .toMaybeBlocking();
         verify(function1, times(1)).apply("HelloWorld");
-        verify(recoveryFunction, times(1)).apply(any(CompletionException.class)); /* <-- MaybeTestException2 wrapped by completable future*/
+        verify(recoveryFunction, times(1)).apply(any(MaybeTestException2.class)); /* <-- MaybeTestException2 wrapped by completable future*/
         verify(function2, times(1)).apply(42);
         assertThat(maybe.hasException()).isFalse();
         assertThat(maybe.value()).isEqualTo("OK");
@@ -287,8 +285,7 @@ public class AsyncMaybeTest {
 
     @Test
     public void toMaybeWithTimeoutThrowsWhenReached() {
-        CompletableFuture<Object> future = new CompletableFuture<>();
-        Maybe<Object> maybe = AsyncMaybe.fromCompletableFuture(future).toMaybeBlocking(Duration.ofSeconds(2));
+        Maybe<Void> maybe = AsyncMaybe.attemptAsync(() -> Thread.sleep(10000)).toMaybeBlocking(Duration.ofSeconds(2));
         assertThat(maybe.exception()).isInstanceOf(TimeoutException.class);
     }
 
@@ -310,18 +307,14 @@ public class AsyncMaybeTest {
         Maybe<String> result = AsyncMaybe.attemptAsync(() -> {
             throw exception;
         }).map(any -> "Not called").toMaybeBlocking();
-        assertThat(result.exception()).hasCause(exception);
+        assertThat(result.exception()).isEqualTo(exception);
     }
 
     @Test
     public void mapIsNotCalledOnException() {
         RuntimeException exception = new RuntimeException("Testing exception");
         Maybe<String> result = AsyncMaybe.ofException(exception).map(any -> any + "Not called").toMaybeBlocking();
-        assertThat(result.exception()).hasCause(exception);
-    }
-
-    private static Throwable anyExceptionWithCause(Class<? extends Throwable> throwableClass) {
-        return ArgumentMatchers.argThat(t -> throwableClass.isAssignableFrom(t.getCause().getClass()));
+        assertThat(result.exception()).isEqualTo(exception);
     }
 
 }

--- a/src/test/java/org/ossgang/commons/monads/AsyncMaybeTest.java
+++ b/src/test/java/org/ossgang/commons/monads/AsyncMaybeTest.java
@@ -269,21 +269,6 @@ public class AsyncMaybeTest {
     }
 
     @Test
-    public void whenCompleteBiconsumerWithValueIsCalled() {
-        CompletableFuture<String> result = new CompletableFuture<>();
-        AsyncMaybe.ofValue("Value").whenComplete((value, exception) -> result.complete(value));
-        assertThat(result.join()).isEqualTo("Value");
-    }
-
-    @Test
-    public void whenCompleteBiconsumerWithExceptionIsCalled() {
-        CompletableFuture<Throwable> result = new CompletableFuture<>();
-        RuntimeException thrownException = new RuntimeException("Exception test");
-        AsyncMaybe.ofException(thrownException).whenComplete((value, exception) -> result.complete(exception));
-        assertThat(result.join()).isSameAs(thrownException);
-    }
-
-    @Test
     public void toMaybeWithTimeoutThrowsWhenReached() {
         Maybe<Void> maybe = AsyncMaybe.attemptAsync(() -> Thread.sleep(10000)).toMaybeBlocking(Duration.ofSeconds(2));
         assertThat(maybe.exception()).isInstanceOf(TimeoutException.class);

--- a/src/test/java/org/ossgang/commons/monads/AsyncMaybeVoidTest.java
+++ b/src/test/java/org/ossgang/commons/monads/AsyncMaybeVoidTest.java
@@ -1,0 +1,83 @@
+/*
+ * @formatter:off
+ * Copyright (c) 2008-2020, CERN. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * @formatter:on
+ */
+
+package org.ossgang.commons.monads;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class AsyncMaybeVoidTest {
+
+    @Test
+    public void testAsyncMaybeVoid_afterWhenValue_shouldNotThrowNPE() {
+        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {});
+        AsyncMaybe<Void> async2 = async1.whenValue(v -> {});
+        async2.toMaybeBlocking().throwOnException();
+    }
+
+    @Test
+    public void testAsyncMaybeVoid_afterWhenException_shouldNotThrowNPE() {
+        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {
+            throw new RuntimeException("testAsyncMaybeVoid_afterWhenException_shouldNotThrowNPE");
+        });
+        AsyncMaybe<Void> async2 = async1.whenException(e -> {});
+        Maybe<Void> maybe = async2.toMaybeBlocking();
+        Assertions.assertThat(maybe.exception().getCause()).hasMessage("testAsyncMaybeVoid_afterWhenException_shouldNotThrowNPE");
+    }
+
+    @Test
+    public void testAsyncMaybeVoid_afterRecover_shouldNotThrowNPE() {
+        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {
+            throw new RuntimeException();
+        });
+        AsyncMaybe<Void> async2 = async1.recover(e -> {
+        });
+        async2.toMaybeBlocking().throwOnException();
+    }
+
+    @Test
+    public void testAsyncMaybeVoid_afterThenConsumer_shouldNotThrowNPE() {
+        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {});
+        AsyncMaybe<Void> async2 = async1.then(any -> {});
+        async2.toMaybeBlocking().throwOnException();
+    }
+
+    @Test
+    public void testAsyncMaybeVoid_afterThenRunnable_shouldNotThrowNPE() {
+        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {});
+        AsyncMaybe<Void> async2 = async1.then(() -> {});
+        async2.toMaybeBlocking().throwOnException();
+    }
+
+    @Test
+    public void testAsyncMaybeVoid_afterWhenCompleteBiConsumer_shouldNotThrowNPE() {
+        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {});
+        AsyncMaybe<Void> async2 = async1.whenComplete((any, error) -> {});
+        async2.toMaybeBlocking().throwOnException();
+    }
+
+    @Test
+    public void testAsyncMaybeVoid_afterWhenCompleteConsumer_shouldNotThrowNPE() {
+        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {
+        });
+        AsyncMaybe<Void> async2 = async1.whenComplete(maybe -> {
+        });
+        async2.toMaybeBlocking().throwOnException();
+    }
+
+}

--- a/src/test/java/org/ossgang/commons/monads/AsyncMaybeVoidTest.java
+++ b/src/test/java/org/ossgang/commons/monads/AsyncMaybeVoidTest.java
@@ -24,9 +24,20 @@ import org.junit.Test;
 public class AsyncMaybeVoidTest {
 
     @Test
+    public void testWhenCompleteVoid() {
+        AsyncMaybe<Void> async = AsyncMaybe.attemptAsync(() -> {
+        });
+        async.whenComplete(maybe -> {
+        });
+        async.toMaybeBlocking().throwOnException();
+    }
+
+    @Test
     public void testAsyncMaybeVoid_afterWhenValue_shouldNotThrowNPE() {
-        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {});
-        AsyncMaybe<Void> async2 = async1.whenValue(v -> {});
+        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {
+        });
+        AsyncMaybe<Void> async2 = async1.whenValue(v -> {
+        });
         async2.toMaybeBlocking().throwOnException();
     }
 
@@ -35,9 +46,10 @@ public class AsyncMaybeVoidTest {
         AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {
             throw new RuntimeException("testAsyncMaybeVoid_afterWhenException_shouldNotThrowNPE");
         });
-        AsyncMaybe<Void> async2 = async1.whenException(e -> {});
+        AsyncMaybe<Void> async2 = async1.whenException(e -> {
+        });
         Maybe<Void> maybe = async2.toMaybeBlocking();
-        Assertions.assertThat(maybe.exception().getCause()).hasMessage("testAsyncMaybeVoid_afterWhenException_shouldNotThrowNPE");
+        Assertions.assertThat(maybe.exception()).hasMessage("testAsyncMaybeVoid_afterWhenException_shouldNotThrowNPE");
     }
 
     @Test
@@ -52,22 +64,28 @@ public class AsyncMaybeVoidTest {
 
     @Test
     public void testAsyncMaybeVoid_afterThenConsumer_shouldNotThrowNPE() {
-        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {});
-        AsyncMaybe<Void> async2 = async1.then(any -> {});
+        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {
+        });
+        AsyncMaybe<Void> async2 = async1.then(any -> {
+        });
         async2.toMaybeBlocking().throwOnException();
     }
 
     @Test
     public void testAsyncMaybeVoid_afterThenRunnable_shouldNotThrowNPE() {
-        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {});
-        AsyncMaybe<Void> async2 = async1.then(() -> {});
+        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {
+        });
+        AsyncMaybe<Void> async2 = async1.then(() -> {
+        });
         async2.toMaybeBlocking().throwOnException();
     }
 
     @Test
     public void testAsyncMaybeVoid_afterWhenCompleteBiConsumer_shouldNotThrowNPE() {
-        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {});
-        AsyncMaybe<Void> async2 = async1.whenComplete((any, error) -> {});
+        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {
+        });
+        AsyncMaybe<Void> async2 = async1.whenComplete((any, error) -> {
+        });
         async2.toMaybeBlocking().throwOnException();
     }
 

--- a/src/test/java/org/ossgang/commons/monads/AsyncMaybeVoidTest.java
+++ b/src/test/java/org/ossgang/commons/monads/AsyncMaybeVoidTest.java
@@ -81,15 +81,6 @@ public class AsyncMaybeVoidTest {
     }
 
     @Test
-    public void testAsyncMaybeVoid_afterWhenCompleteBiConsumer_shouldNotThrowNPE() {
-        AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {
-        });
-        AsyncMaybe<Void> async2 = async1.whenComplete((any, error) -> {
-        });
-        async2.toMaybeBlocking().throwOnException();
-    }
-
-    @Test
     public void testAsyncMaybeVoid_afterWhenCompleteConsumer_shouldNotThrowNPE() {
         AsyncMaybe<Void> async1 = AsyncMaybe.attemptAsync(() -> {
         });


### PR DESCRIPTION
The case of Void is particularly complex since the `Maybe` interface will not accept it as a value..
Since behind the scenes an `AsyncMaybe` is a `CompletableFuture`, the API doesn't make the difference between `Void` or `T` and null is always allowed.

As an example, the following piece of code fails on the `.toMaybeBlocking()` since it is trying to assign `null` as a value of the `Maybe`:
```java
AsyncMaybe.attemptAsync(() -> System.out.println("Ok"))
                .whenException(e -> System.err.println("Err"))
                .toMaybeBlocking().throwOnException();
```