### PR TITLE
Fix unhandled exception in case of no subscribers

### DIFF
--- a/src/main/java/org/ossgang/commons/observables/DispatchingObservable.java
+++ b/src/main/java/org/ossgang/commons/observables/DispatchingObservable.java
@@ -91,29 +91,22 @@ public class DispatchingObservable<T> implements Observable<T> {
         allSubscriptions.forEach(Subscription::unsubscribe);
     }
 
-    protected void dispatchValue(T newValue) {
-        listeners.keySet().forEach(l -> dispatch(l::onValue, newValue));
+    protected final void dispatchValue(T newValue) {
+        dispatchValue(newValue, any -> true);
     }
 
-    protected void dispatchValue(T newValue, Predicate<Set<SubscriptionOption>> optionPredicate) {
+    protected final void dispatchValue(T newValue, Predicate<Set<SubscriptionOption>> optionPredicate) {
         listeners.entrySet().stream() //
                 .filter(entry -> optionPredicate.test(entry.getValue().options)) //
                 .map(Map.Entry::getKey) //
                 .forEach(l -> dispatch(l::onValue, newValue));
     }
 
-    protected void dispatchException(Throwable exception) {
-        AtomicBoolean wasDispatched = new AtomicBoolean(false);
-        listeners.keySet().forEach(l -> {
-            dispatch(l::onException, exception);
-            wasDispatched.set(true);
-        });
-        if (!wasDispatched.get()) {
-            dispatchToUncaughtExceptionHandler(new UnhandledException(exception));
-        }
+    protected final void dispatchException(Throwable exception) {
+        dispatchException(exception, any -> true);
     }
 
-    protected void dispatchException(Throwable exception, Predicate<Set<SubscriptionOption>> optionPredicate) {
+    protected final void dispatchException(Throwable exception, Predicate<Set<SubscriptionOption>> optionPredicate) {
         AtomicBoolean wasDispatched = new AtomicBoolean(false);
         listeners.entrySet().stream() //
                 .filter(entry -> optionPredicate.test(entry.getValue().options)) //

--- a/src/main/java/org/ossgang/commons/observables/DispatchingObservable.java
+++ b/src/main/java/org/ossgang/commons/observables/DispatchingObservable.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -102,14 +103,28 @@ public class DispatchingObservable<T> implements Observable<T> {
     }
 
     protected void dispatchException(Throwable exception) {
-        listeners.keySet().forEach(l -> dispatch(l::onException, exception));
+        AtomicBoolean wasDispatched = new AtomicBoolean(false);
+        listeners.keySet().forEach(l -> {
+            dispatch(l::onException, exception);
+            wasDispatched.set(true);
+        });
+        if (!wasDispatched.get()) {
+            dispatchToUncaughtExceptionHandler(new UnhandledException(exception));
+        }
     }
 
     protected void dispatchException(Throwable exception, Predicate<Set<SubscriptionOption>> optionPredicate) {
+        AtomicBoolean wasDispatched = new AtomicBoolean(false);
         listeners.entrySet().stream() //
                 .filter(entry -> optionPredicate.test(entry.getValue().options)) //
                 .map(Map.Entry::getKey) //
-                .forEach(l -> dispatch(l::onException, exception));
+                .forEach(l -> {
+                    dispatch(l::onException, exception);
+                    wasDispatched.set(true);
+                });
+        if (!wasDispatched.get()) {
+            dispatchToUncaughtExceptionHandler(new UnhandledException(exception));
+        }
     }
 
     protected <X> Future<?> dispatch(Consumer<X> handler, X value) {

--- a/src/test/java/org/ossgang/commons/observables/ExceptionHandlersTest.java
+++ b/src/test/java/org/ossgang/commons/observables/ExceptionHandlersTest.java
@@ -39,8 +39,20 @@ public class ExceptionHandlersTest {
 
     @Test
     public void mapThrows_subscriberDoesNotHandle_shouldDeflect() throws Exception {
-        Property<String> property = Properties.property("A");
+        Property<String> property = Properties.property();
         property.map(Integer::valueOf).subscribe(System.out::println);
+        property.set("THIS-IS-NOT-A-NUMBER");
+
+        assertThat(exception.get(1, SECONDS))
+                .isInstanceOf(UnhandledException.class)
+                .hasMessageContaining("THIS-IS-NOT-A-NUMBER")
+                .hasCauseInstanceOf(NumberFormatException.class);
+    }
+
+    @Test
+    public void mapThrows_noSubscriberIsPresent_shouldDeflect() throws Exception {
+        Property<String> property = Properties.property();
+        property.map(Integer::valueOf);
         property.set("THIS-IS-NOT-A-NUMBER");
 
         assertThat(exception.get(1, SECONDS))
@@ -61,7 +73,7 @@ public class ExceptionHandlersTest {
     @Test(expected = TimeoutException.class)
     public void mapThrows_subscriberHandles_shouldNotDeflect() throws Exception {
         TestObserver<Integer> testObserver = new TestObserver<>();
-        Property<String> property = Properties.property("A");
+        Property<String> property = Properties.property();
         property.map(Integer::valueOf).subscribe(testObserver);
         property.set("THIS-IS-NOT-A-NUMBER");
 


### PR DESCRIPTION
Since our Observables are "hot", all the operators are always executed even if no one subscribes to them.
In this case, an unhandled exception was swallowed: e.g. clients that only polls the ObservableValue will see nothing if there's an exception in a map operator.

This is a proposal lock-free fix + test. 