### PR TITLE
Remove the static GC protection mechanism for observables.

### DIFF
--- a/src/main/java/org/ossgang/commons/awaitables/BaseAwaitable.java
+++ b/src/main/java/org/ossgang/commons/awaitables/BaseAwaitable.java
@@ -30,7 +30,7 @@ import org.ossgang.commons.awaitables.exceptions.AwaitTimeoutException;
 @SuppressWarnings("unchecked")
 class BaseAwaitable<T, A extends BaseAwaitable<T, A>> {
     private static final ExecutorService AWAITER_POOL =
-            newCachedThreadPool(daemonThreadFactoryWithPrefix("ossgang-Awaitables-awaiter"));
+            newCachedThreadPool(daemonThreadFactoryWithPrefix("ossgang-commons-Awaitable-"));
 
     private static final Duration DEFAULT_RETRY_INTERVAL = Duration.ofMillis(100);
     private static final int DEFAULT_RETRY_COUNT = Integer.MAX_VALUE;

--- a/src/main/java/org/ossgang/commons/monads/AsyncMaybe.java
+++ b/src/main/java/org/ossgang/commons/monads/AsyncMaybe.java
@@ -46,7 +46,8 @@ import java.util.function.Supplier;
  */
 public class AsyncMaybe<T> {
 
-    private static final ExecutorService ASYNC_MAYBE_POOL = newCachedThreadPool(daemonThreadFactoryWithPrefix("ossgang-AsyncMaybe-executor"));
+    private static final ExecutorService ASYNC_MAYBE_POOL = newCachedThreadPool(
+            daemonThreadFactoryWithPrefix("ossgang-commons-AsyncMaybe-"));
     private static final String NULL_VALUE_MSG = "AsyncMaybe cannot contain a null value";
 
     private final CompletableFuture<Maybe<T>> stage;

--- a/src/main/java/org/ossgang/commons/observables/DispatchingObservable.java
+++ b/src/main/java/org/ossgang/commons/observables/DispatchingObservable.java
@@ -51,7 +51,7 @@ import org.ossgang.commons.observables.exceptions.UpdateDeliveryException;
  */
 public class DispatchingObservable<T> implements Observable<T> {
     private static final ExecutorService DISPATCHER_POOL = newCachedThreadPool(
-            daemonThreadFactoryWithPrefix("ossgang-Observable-dispatcher-"));
+            daemonThreadFactoryWithPrefix("ossgang-commons-DispatchingObservable-dispatcher-"));
     private final Map<Observer<? super T>, ObservableSubscription<T>> observers = new ConcurrentHashMap<>();
 
     protected DispatchingObservable() {

--- a/src/main/java/org/ossgang/commons/observables/DispatchingObservable.java
+++ b/src/main/java/org/ossgang/commons/observables/DispatchingObservable.java
@@ -138,18 +138,18 @@ public class DispatchingObservable<T> implements Observable<T> {
     private static class ObservableSubscription<T> implements Subscription {
         private final Observer<? super T> listener;
         private final Set<SubscriptionOption> options;
-        private final WeakReference<DispatchingObservable<T>> observable;
+        private final DispatchingObservable<T> observable;
 
         private ObservableSubscription(DispatchingObservable<T> observable, Observer<? super T> listener,
                 Set<SubscriptionOption> options) {
-            this.observable = new WeakReference<>(observable);
+            this.observable = observable;
             this.listener = listener;
             this.options = options;
         }
 
         @Override
         public void unsubscribe() {
-            Optional.ofNullable(observable.get()).ifPresent(obs -> obs.removeListener(listener));
+            observable.removeListener(listener);
             listener.onUnsubscribe(this);
         }
     }

--- a/src/main/java/org/ossgang/commons/observables/DispatchingObservableValue.java
+++ b/src/main/java/org/ossgang/commons/observables/DispatchingObservableValue.java
@@ -52,12 +52,12 @@ public class DispatchingObservableValue<T> extends DispatchingObservable<T> impl
     }
 
     @Override
-    public Subscription subscribe(Observer<? super T> listener, SubscriptionOption... options) {
+    public Subscription subscribe(Observer<? super T> observer, SubscriptionOption... options) {
         Set<SubscriptionOption> optionSet = new HashSet<>(Arrays.asList(options));
-        Subscription subscription = super.subscribe(listener, options);
+        Subscription subscription = super.subscribe(observer, options);
         if (optionSet.contains(FIRST_UPDATE)) {
             Optional.ofNullable(lastValue.get())
-                    .ifPresent(uncheckedConsumer(value -> dispatch(listener::onValue, value).get()));
+                    .ifPresent(uncheckedConsumer(value -> dispatch(observer::onValue, value).get()));
         }
         return subscription;
     }

--- a/src/main/java/org/ossgang/commons/observables/Observables.java
+++ b/src/main/java/org/ossgang/commons/observables/Observables.java
@@ -745,6 +745,8 @@ public final class Observables {
      * <li>If an observer onNext/onException throws, with an {@link UpdateDeliveryException}</li>
      * <li>If an observer does not implement onException and an exception would be delivered, by
      * an {@link UnhandledException}</li>
+     * <li>If an internal error occurs in the framework (e.g. during cleanup of a weak observer), with an
+     * {@link IllegalStateException}</li>
      * </ul>
      * In either case, getCause() can be used to obtain the original exception.
      *

--- a/src/main/java/org/ossgang/commons/observables/Observables.java
+++ b/src/main/java/org/ossgang/commons/observables/Observables.java
@@ -21,10 +21,9 @@ package org.ossgang.commons.observables;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -32,21 +31,16 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.ossgang.commons.monads.Consumer3;
-import org.ossgang.commons.monads.Consumer4;
-import org.ossgang.commons.monads.Consumer5;
-import org.ossgang.commons.monads.Function3;
-import org.ossgang.commons.monads.Function4;
-import org.ossgang.commons.monads.Function5;
+import org.ossgang.commons.monads.*;
 import org.ossgang.commons.observables.exceptions.UnhandledException;
 import org.ossgang.commons.observables.exceptions.UpdateDeliveryException;
-import org.ossgang.commons.observables.operators.CombinationOperators;
-import org.ossgang.commons.observables.operators.DebouncedObservableValue;
-import org.ossgang.commons.observables.operators.Operators;
-import org.ossgang.commons.observables.operators.SubscribeValuesOperators;
+import org.ossgang.commons.observables.operators.*;
 import org.ossgang.commons.observables.operators.connectors.ConnectorObservableValue;
 import org.ossgang.commons.observables.operators.connectors.ConnectorObservables;
 import org.ossgang.commons.observables.operators.connectors.DynamicConnectorObservableValue;
+import org.ossgang.commons.utils.NamedDaemonThreadFactory;
+
+import static org.ossgang.commons.utils.NamedDaemonThreadFactory.daemonThreadFactoryWithPrefix;
 
 /**
  * Static support class for dealing with {@link Observable} and {@link ObservableValue}.
@@ -246,7 +240,7 @@ public final class Observables {
      * result of combiner applied with the latest values of the other inputs.
      */
     public static <K, O> ObservableValue<O> zipObjects(Map<K, ? extends Observable<?>> sourcesMap,
-            Function<Map<K, Object>, O> combiner) {
+                                                       Function<Map<K, Object>, O> combiner) {
         return CombinationOperators.zipObjects(sourcesMap, combiner);
     }
 
@@ -265,7 +259,7 @@ public final class Observables {
      * combiner applied with the latest values of the other inputs.
      */
     public static <O> ObservableValue<O> zipObjects(List<? extends Observable<?>> sources,
-            Function<List<Object>, O> combiner) {
+                                                    Function<List<Object>, O> combiner) {
         return CombinationOperators.zipObjects(sources, combiner);
     }
 
@@ -317,7 +311,7 @@ public final class Observables {
      * with the latest values of the other input
      */
     public static <I1, I2, O> ObservableValue<O> zip(Observable<I1> source1, Observable<I2> source2,
-            BiFunction<I1, I2, O> combiner) {
+                                                     BiFunction<I1, I2, O> combiner) {
         return CombinationOperators.zip(source1, source2, combiner);
     }
 
@@ -338,8 +332,8 @@ public final class Observables {
      * with the latest values of the other input
      */
     public static <I1, I2, I3, O> ObservableValue<O> zip(Observable<I1> source1, Observable<I2> source2,
-            Observable<I3> source3,
-            Function3<I1, I2, I3, O> combiner) {
+                                                         Observable<I3> source3,
+                                                         Function3<I1, I2, I3, O> combiner) {
         return CombinationOperators.zip(source1, source2, source3, combiner);
     }
 
@@ -362,8 +356,8 @@ public final class Observables {
      * with the latest values of the other input
      */
     public static <I1, I2, I3, I4, O> ObservableValue<O> zip(Observable<I1> source1, Observable<I2> source2,
-            Observable<I3> source3, Observable<I4> source4,
-            Function4<I1, I2, I3, I4, O> combiner) {
+                                                             Observable<I3> source3, Observable<I4> source4,
+                                                             Function4<I1, I2, I3, I4, O> combiner) {
         return CombinationOperators.zip(source1, source2, source3, source4, combiner);
     }
 
@@ -388,9 +382,9 @@ public final class Observables {
      * with the latest values of the other input
      */
     public static <I1, I2, I3, I4, I5, O> ObservableValue<O> zip(Observable<I1> source1, Observable<I2> source2,
-            Observable<I3> source3, Observable<I4> source4,
-            Observable<I5> source5,
-            Function5<I1, I2, I3, I4, I5, O> combiner) {
+                                                                 Observable<I3> source3, Observable<I4> source4,
+                                                                 Observable<I5> source5,
+                                                                 Function5<I1, I2, I3, I4, I5, O> combiner) {
         return CombinationOperators.zip(source1, source2, source3, source4, source5, combiner);
     }
 

--- a/src/main/java/org/ossgang/commons/observables/Observers.java
+++ b/src/main/java/org/ossgang/commons/observables/Observers.java
@@ -1,6 +1,7 @@
 package org.ossgang.commons.observables;
 
 import org.ossgang.commons.monads.Maybe;
+import org.ossgang.commons.observables.exceptions.UnhandledException;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -89,9 +90,7 @@ public class Observers {
      * subscription will be kept alive.
      */
     public static <C, T> Observer<T> weak(C holder, BiConsumer<C, T> valueConsumer) {
-        return new WeakMethodReferenceObserver<>(holder, valueConsumer, (a, b) -> {
-        }, (a, b) -> {
-        });
+        return new WeakMethodReferenceObserver<>(holder, valueConsumer);
     }
 
     /**
@@ -99,17 +98,6 @@ public class Observers {
      */
     public static <C, T> Observer<T> weakWithErrorHandling(C holder, BiConsumer<? super C, T> valueConsumer,
                                                            BiConsumer<? super C, Throwable> exceptionConsumer) {
-        return new WeakMethodReferenceObserver<>(holder, valueConsumer, exceptionConsumer, (a, b) -> {
-        });
-    }
-
-    /**
-     * @see #weak(Object, BiConsumer)
-     */
-    public static <C, T> Observer<T> weakWithErrorAndSubscriptionCountHandling(C holder,
-                                                                               BiConsumer<? super C, T> valueConsumer,
-                                                                               BiConsumer<? super C, Throwable> exceptionConsumer,
-                                                                               BiConsumer<? super C, Integer> subscriptionCountChanged) {
-        return new WeakMethodReferenceObserver<>(holder, valueConsumer, exceptionConsumer, subscriptionCountChanged);
+        return new WeakMethodReferenceObserver<>(holder, valueConsumer, exceptionConsumer);
     }
 }

--- a/src/main/java/org/ossgang/commons/observables/PeriodicObservableValue.java
+++ b/src/main/java/org/ossgang/commons/observables/PeriodicObservableValue.java
@@ -13,11 +13,16 @@ import java.util.concurrent.TimeUnit;
  */
 public class PeriodicObservableValue extends DispatchingObservableValue<Instant> {
 
-    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(daemonThreadFactoryWithPrefix("periodic-observable"));
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
+            daemonThreadFactoryWithPrefix("ossgang-commons-PeriodicObservable-"));
 
     PeriodicObservableValue(long period, TimeUnit unit) {
         super(Instant.now());
         executor.scheduleAtFixedRate(() -> dispatchValue(Instant.now()), 0, period, unit);
     }
 
+    @Override
+    protected void finalize() {
+        executor.shutdown();
+    }
 }

--- a/src/main/java/org/ossgang/commons/observables/WeakMethodReferenceObserver.java
+++ b/src/main/java/org/ossgang/commons/observables/WeakMethodReferenceObserver.java
@@ -82,7 +82,7 @@ public class WeakMethodReferenceObserver<C, T> extends WeakReference<C> implemen
 
     @Override
     public synchronized void onSubscribe(Subscription subscription) {
-        if (subscriptions == null) {
+        if (isCleanedUp()) {
             subscription.unsubscribe();
             throw new IllegalStateException("Weak observer has been garbage collected and can not be re-used!");
         }
@@ -91,7 +91,7 @@ public class WeakMethodReferenceObserver<C, T> extends WeakReference<C> implemen
 
     @Override
     public synchronized void onUnsubscribe(Subscription subscription) {
-        if (subscriptions == null) {
+        if (isCleanedUp()) {
             return;
         }
         subscriptions.remove(subscription);
@@ -102,6 +102,10 @@ public class WeakMethodReferenceObserver<C, T> extends WeakReference<C> implemen
         subscriptions = null;
         valueConsumer = null;
         exceptionConsumer = null;
+    }
+
+    protected final synchronized boolean isCleanedUp() {
+        return subscriptions == null;
     }
 
     private <X> void dispatch(BiConsumer<? super C, X> consumer, X item) {

--- a/src/main/java/org/ossgang/commons/observables/WeakMethodReferenceObserver.java
+++ b/src/main/java/org/ossgang/commons/observables/WeakMethodReferenceObserver.java
@@ -121,7 +121,7 @@ public class WeakMethodReferenceObserver<C, T> extends WeakReference<C> implemen
                 }
             }
         });
-        cleanupThread.setName("ossgang-commons-weakobserver-finalizer");
+        cleanupThread.setName("ossgang-commons-WeakMethodReferenceObserver-finalizer");
         cleanupThread.setDaemon(true);
         cleanupThread.start();
     }

--- a/src/main/java/org/ossgang/commons/observables/WeakMethodReferenceObserver.java
+++ b/src/main/java/org/ossgang/commons/observables/WeakMethodReferenceObserver.java
@@ -22,21 +22,18 @@
 
 package org.ossgang.commons.observables;
 
-import org.ossgang.commons.monads.Maybe;
 import org.ossgang.commons.observables.exceptions.UnhandledException;
+import org.ossgang.commons.observables.operators.AbstractOperatorObservableValue;
 
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
-import static org.ossgang.commons.utils.NamedDaemonThreadFactory.daemonThreadFactoryWithPrefix;
 
 /**
  * An observer based on a weak reference to an object, and class method references to consumers for values (and,
@@ -54,46 +51,24 @@ import static org.ossgang.commons.utils.NamedDaemonThreadFactory.daemonThreadFac
  * This will allow the "Test" instance to be GC'd, terminating the subscription; but for as long as it lives, the
  * subscription will be kept alive.
  */
-class WeakMethodReferenceObserver<C, T> implements Observer<T> {
-
-    /* Visible for testing */
-    static final int DEFAULT_CLEANUP_PERIOD_SEC = 30;
-    private static final String CLEANUP_PERIOD_SYS_PROPERTY = "org.ossgang.commons.observables.weak_cleanup_period";
-    private static final Set<WeakCleaner> REFERENCE_CLEANERS = Collections.newSetFromMap(new ConcurrentHashMap<>());
-    private static final ScheduledExecutorService REFERENCE_CLEANUP_EXECUTOR = newSingleThreadScheduledExecutor(
-            daemonThreadFactoryWithPrefix("ossgang-weak-observer-cleanup"));
-
-    static {
-        Integer cleanupPeriod = Integer.getInteger(CLEANUP_PERIOD_SYS_PROPERTY, DEFAULT_CLEANUP_PERIOD_SEC);
-        Runnable cleanupRunnable = () -> REFERENCE_CLEANERS.removeIf(c -> c.attemptToClean()
-                .ifException(WeakMethodReferenceObserver::dispatchToUncaughtExceptionHandler)
-                .optionalValue().orElse(false));
-        REFERENCE_CLEANUP_EXECUTOR.scheduleAtFixedRate(cleanupRunnable, cleanupPeriod, cleanupPeriod, TimeUnit.SECONDS);
-    }
-
-    private static void dispatchToUncaughtExceptionHandler(Throwable t) {
-        if (t instanceof UnhandledException) {
-            ExceptionHandlers.dispatchToUncaughtExceptionHandler((UnhandledException) t);
-        } else {
-            ExceptionHandlers.dispatchToUncaughtExceptionHandler(new UnhandledException(t));
-        }
-    }
-
-    private final WeakReference<C> holderRef;
+public class WeakMethodReferenceObserver<C, T> extends WeakReference<C> implements Observer<T> {
+    private static final ReferenceQueue<Object> STALE_WEAK_OBSERVERS = new ReferenceQueue<>();
     private final BiConsumer<? super C, T> valueConsumer;
     private final BiConsumer<? super C, Throwable> exceptionConsumer;
-    private final BiConsumer<? super C, Integer> subscriptionCountUpdated;
 
     private final Set<Subscription> subscriptions = new HashSet<>();
 
-    WeakMethodReferenceObserver(C holder, BiConsumer<? super C, T> valueConsumer,
-                                BiConsumer<? super C, Throwable> exceptionConsumer,
-                                BiConsumer<? super C, Integer> subscriptionCountUpdated) {
-        this.holderRef = new WeakReference<>(holder);
+    protected WeakMethodReferenceObserver(C holder, BiConsumer<? super C, T> valueConsumer,
+            BiConsumer<? super C, Throwable> exceptionConsumer) {
+        super(holder, STALE_WEAK_OBSERVERS);
         this.valueConsumer = valueConsumer;
         this.exceptionConsumer = exceptionConsumer;
-        this.subscriptionCountUpdated = subscriptionCountUpdated;
-        REFERENCE_CLEANERS.add(new WeakCleaner(holderRef, this::unsubscribeAll));
+    }
+
+    protected WeakMethodReferenceObserver(C holder, BiConsumer<? super C, T> valueConsumer) {
+        this(holder, valueConsumer, (r, e) -> {
+            throw new UnhandledException(e);
+        });
     }
 
     private void unsubscribeAll() {
@@ -117,7 +92,6 @@ class WeakMethodReferenceObserver<C, T> implements Observer<T> {
     public void onSubscribe(Subscription subscription) {
         synchronized (subscriptions) {
             subscriptions.add(subscription);
-            Optional.ofNullable(holderRef.get()).ifPresent(h -> subscriptionCountUpdated.accept(h, subscriptions.size()));
         }
     }
 
@@ -125,38 +99,28 @@ class WeakMethodReferenceObserver<C, T> implements Observer<T> {
     public void onUnsubscribe(Subscription subscription) {
         synchronized (subscriptions) {
             subscriptions.remove(subscription);
-            Optional.ofNullable(holderRef.get()).ifPresent(h -> subscriptionCountUpdated.accept(h, subscriptions.size()));
         }
     }
 
     private <X> void dispatch(BiConsumer<? super C, X> consumer, X item) {
-        C holderInstance = holderRef.get();
-        if (holderInstance != null) {
-            consumer.accept(holderInstance, item);
-        } else {
-            unsubscribeAll();
-        }
+        Optional.ofNullable(get()).ifPresent(ref -> consumer.accept(ref, item));
     }
 
-    private static class WeakCleaner {
-
-        private final WeakReference<?> holderRef;
-        private final Runnable cleanupAction;
-
-        public WeakCleaner(WeakReference<?> holderRef, Runnable cleanupAction) {
-            this.holderRef = holderRef;
-            this.cleanupAction = cleanupAction;
-        }
-
-        public Maybe<Boolean> attemptToClean() {
-            return Maybe.attempt(() -> {
-                if (holderRef.get() == null) {
-                    cleanupAction.run();
-                    return true;
+    static {
+        Thread cleanupThread = new Thread(() -> {
+            while (!Thread.interrupted()) {
+                try {
+                    Reference<?> ref = STALE_WEAK_OBSERVERS.remove();
+                    WeakMethodReferenceObserver<?, ?> observer = (WeakMethodReferenceObserver<?, ?>) ref;
+                    observer.unsubscribeAll();
+                } catch (Exception e) {
+                    ExceptionHandlers.dispatchToUncaughtExceptionHandler(
+                            new IllegalStateException("Error in WeakMethodReferenceObserver finalizer", e));
                 }
-                return false;
-            });
-        }
+            }
+        });
+        cleanupThread.setName("ossgang-commons-weakobserver-finalizer");
+        cleanupThread.setDaemon(true);
+        cleanupThread.start();
     }
-
 }

--- a/src/main/java/org/ossgang/commons/observables/operators/AbstractOperatorObservableValue.java
+++ b/src/main/java/org/ossgang/commons/observables/operators/AbstractOperatorObservableValue.java
@@ -1,0 +1,117 @@
+package org.ossgang.commons.observables.operators;
+
+import org.ossgang.commons.observables.Observable;
+import org.ossgang.commons.observables.Observer;
+import org.ossgang.commons.observables.*;
+
+import java.lang.ref.WeakReference;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+import static org.ossgang.commons.observables.SubscriptionOptions.FIRST_UPDATE;
+
+/**
+ * A base {@link ObservableValue} which gets its data from parents (upstream) {@link ObservableValue} or {@link Observable},
+ * applying an operation. Operations can be arbitrary but must be side-effect free, e.g. mapping or filtering.
+ * If an operation fails (e.g. a mapping function throws), the exception is propagated downstream.
+ * <p>
+ * The subscription to the upstream observable is eager (as soon as this class is instantiated), even if there are no
+ * subscribers. Subscription upstream are "possibly weak". If there are no observers downstream, the upstream observer
+ * reference "this" {@link ObservableValue} weakly. As soon as a downstream observer subscribes, the upstream observer
+ * reference to "this" {@link ObservableValue} becomes strong. When all downstream observers unsubscribe, the upstream
+ * observer reference to "this" {@link ObservableValue} becomes weak again, allowing "this" to be garbage collected.
+ * <p>
+ * There is no guarantee that a call to get() will return the latest item of the upstream observable.
+ *
+ * @param <K> the indexing type
+ * @param <I> the type of the source observable
+ * @param <O> the type of this observable
+ */
+public abstract class AbstractOperatorObservableValue<K, I, O> extends DispatchingObservableValue<O> implements ObservableValue<O> {
+
+    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+    private final List<Subscription> sourceSubscriptions; /* just used to hold strong references upstream */
+    private final List<PossiblyWeakObserver<AbstractOperatorObservableValue<K, I, O>, I>> sourceObservers;
+    private int subscriptionCount = 0;
+
+    protected AbstractOperatorObservableValue() {
+        super(null);
+        this.sourceObservers = new ArrayList<>();
+        this.sourceSubscriptions = new ArrayList<>();
+    }
+
+    protected void subscribeUpstreamWithFirstUpdate(Map<K, ? extends Observable<I>> sourceObservables) {
+        sourceObservables.forEach((key, source) -> {
+            PossiblyWeakObserver<AbstractOperatorObservableValue<K, I, O>, I> observer = new PossiblyWeakObserver<>(this,
+                    (self, item) -> self.applyOperation(key, item),
+                    (self, exception) -> self.dispatchException(exception));
+            this.sourceObservers.add(observer);
+            this.sourceSubscriptions.add(source.subscribe(observer, FIRST_UPDATE));
+        });
+    }
+
+    @Override
+    protected void subscriptionAdded(Observer<? super O> listener, Set<SubscriptionOption> options) {
+        synchronized (sourceObservers) {
+            if (subscriptionCount++ == 0) {
+                sourceObservers.forEach(PossiblyWeakObserver::makeStrong);
+            }
+        }
+    }
+
+    @Override
+    protected void subscriptionRemoved(Observer<? super O> listener) {
+        synchronized (sourceObservers) {
+            if (--subscriptionCount == 0) {
+                sourceObservers.forEach(PossiblyWeakObserver::makeWeak);
+            }
+        }
+    }
+
+    /**
+     * Apply the operation to item delivered by upstream {@link ObservableValue} identified by the key.
+     *
+     * @param key corresponding to the source {@link ObservableValue} that delivered the value
+     * @param item of the source {@link ObservableValue} identified by the key
+     */
+    abstract protected void applyOperation(K key, I item);
+
+    private static class PossiblyWeakObserver<C, T> implements Observer<T> {
+        private final WeakReference<C> holderRef;
+        private final AtomicReference<C> strongHolderRef;
+        private final BiConsumer<? super C, T> valueConsumer;
+        private final BiConsumer<? super C, Throwable> exceptionConsumer;
+
+        PossiblyWeakObserver(C holder, BiConsumer<? super C, T> valueConsumer,
+                             BiConsumer<? super C, Throwable> exceptionConsumer) {
+            this.holderRef = new WeakReference<>(holder);
+            this.strongHolderRef = new AtomicReference<>();
+            this.valueConsumer = valueConsumer;
+            this.exceptionConsumer = exceptionConsumer;
+        }
+
+        public void makeStrong() {
+            strongHolderRef.set(holderRef.get());
+        }
+
+        public void makeWeak() {
+            strongHolderRef.set(null);
+        }
+
+        @Override
+        public void onValue(T t) {
+            dispatch(valueConsumer, t);
+        }
+
+        @Override
+        public void onException(Throwable t) {
+            dispatch(exceptionConsumer, t);
+        }
+
+        private <X> void dispatch(BiConsumer<? super C, X> consumer, X item) {
+            Optional.ofNullable(holderRef.get()).ifPresent(ref -> consumer.accept(ref, item));
+        }
+    }
+
+}

--- a/src/main/java/org/ossgang/commons/observables/operators/DebouncedObservableValue.java
+++ b/src/main/java/org/ossgang/commons/observables/operators/DebouncedObservableValue.java
@@ -48,7 +48,8 @@ public class DebouncedObservableValue<T> extends AbstractOperatorObservableValue
     public DebouncedObservableValue(Observable<T> source, Duration debouncePeriod) {
         this.debouncePeriodMs = debouncePeriod.toMillis();
         this.callback = new AtomicReference<>();
-        this.debouncerExecutor = Executors.newSingleThreadScheduledExecutor(daemonThreadFactoryWithPrefix("ossgang-Observable-debounce-" + System.identityHashCode(this) + "-"));
+        this.debouncerExecutor = Executors.newSingleThreadScheduledExecutor(
+                daemonThreadFactoryWithPrefix("ossgang-commons-DebouncedObservableValue-" + System.identityHashCode(this) + "-"));
         super.subscribeUpstreamWithFirstUpdate(Collections.singletonMap(new Object(), source));
     }
 
@@ -62,4 +63,8 @@ public class DebouncedObservableValue<T> extends AbstractOperatorObservableValue
         });
     }
 
+    @Override
+    protected void finalize() {
+        debouncerExecutor.shutdown();
+    }
 }

--- a/src/main/java/org/ossgang/commons/observables/operators/DerivedObservableValue.java
+++ b/src/main/java/org/ossgang/commons/observables/operators/DerivedObservableValue.java
@@ -19,6 +19,7 @@ import org.ossgang.commons.observables.DispatchingObservableValue;
 import org.ossgang.commons.observables.Observable;
 import org.ossgang.commons.observables.ObservableValue;
 import org.ossgang.commons.observables.Observer;
+import org.ossgang.commons.observables.Subscription;
 import org.ossgang.commons.observables.SubscriptionOption;
 
 /**
@@ -40,7 +41,7 @@ public class DerivedObservableValue<K, I, O> extends DispatchingObservableValue<
     private static final Object SINGLE = new Object();
     private final List<PossiblyWeakObserver<DerivedObservableValue<K, I, O>, I>> sourceObservers;
     @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
-    private final List<Observable<I>> sourceObservables; /* just used to hold strong references upstream */
+    private final List<Subscription> sourceSubscriptions; /* just used to hold strong references upstream */
 
     private int subscriptionCount = 0;
 
@@ -49,14 +50,13 @@ public class DerivedObservableValue<K, I, O> extends DispatchingObservableValue<
         super(null);
         this.mapper = mapper;
         this.sourceObservers = new ArrayList<>();
-        this.sourceObservables = new ArrayList<>();
+        this.sourceSubscriptions = new ArrayList<>();
         sourceObservables.forEach((key, obs) -> {
-            this.sourceObservables.add(obs);
             PossiblyWeakObserver<DerivedObservableValue<K, I, O>, I> observer = new PossiblyWeakObserver<>(this,
                     (self,item) -> self.deriveUpdate(key, item),
                     (self, exception) -> self.dispatchException(exception));
-            obs.subscribe(observer, FIRST_UPDATE);
             this.sourceObservers.add(observer);
+            this.sourceSubscriptions.add(obs.subscribe(observer, FIRST_UPDATE));
         });
     }
 

--- a/src/main/java/org/ossgang/commons/observables/operators/DerivedObservableValue.java
+++ b/src/main/java/org/ossgang/commons/observables/operators/DerivedObservableValue.java
@@ -1,85 +1,38 @@
 package org.ossgang.commons.observables.operators;
 
-import static java.util.Collections.singletonMap;
-import static org.ossgang.commons.monads.Maybe.attempt;
-import static org.ossgang.commons.observables.SubscriptionOptions.FIRST_UPDATE;
+import org.ossgang.commons.observables.Observable;
+import org.ossgang.commons.observables.ObservableValue;
 
-import java.lang.ref.WeakReference;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.ossgang.commons.observables.DispatchingObservableValue;
-import org.ossgang.commons.observables.Observable;
-import org.ossgang.commons.observables.ObservableValue;
-import org.ossgang.commons.observables.Observer;
-import org.ossgang.commons.observables.Subscription;
-import org.ossgang.commons.observables.SubscriptionOption;
+import static java.util.Collections.singletonMap;
+import static org.ossgang.commons.monads.Maybe.attempt;
 
 /**
  * An {@link ObservableValue} which gets its data from a parent (upstream) {@link ObservableValue} or {@link Observable},
  * applying a transformation. Transformations can include arbitrary mapping and/or filtering. If a transformation fails
  * (the mapping function throws), the exception is propagated downstream.
- * <p>
- * The subscription to the upstream observable is eager (as soon as this class is instantiated), even if there are no
- * subscribers.
- * <p>
- * There is no guarantee that a call to get() will return the latest item of the upstream observable.
  *
  * @param <K> the indexing type
  * @param <I> the type of the source observable
  * @param <O> the type of this observable
  */
-public class DerivedObservableValue<K, I, O> extends DispatchingObservableValue<O> implements ObservableValue<O> {
-    private final BiFunction<K, I, Optional<O>> mapper;
-    private static final Object SINGLE = new Object();
-    private final List<PossiblyWeakObserver<DerivedObservableValue<K, I, O>, I>> sourceObservers;
-    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
-    private final List<Subscription> sourceSubscriptions; /* just used to hold strong references upstream */
+public class DerivedObservableValue<K, I, O> extends AbstractOperatorObservableValue<K, I, O> {
 
-    private int subscriptionCount = 0;
+    private static final Object SINGLE = new Object();
+    private final BiFunction<K, I, Optional<O>> mapper;
 
     private DerivedObservableValue(Map<K, ? extends Observable<I>> sourceObservables,
-            BiFunction<K, I, Optional<O>> mapper) {
-        super(null);
+                                   BiFunction<K, I, Optional<O>> mapper) {
         this.mapper = mapper;
-        this.sourceObservers = new ArrayList<>();
-        this.sourceSubscriptions = new ArrayList<>();
-        sourceObservables.forEach((key, obs) -> {
-            PossiblyWeakObserver<DerivedObservableValue<K, I, O>, I> observer = new PossiblyWeakObserver<>(this,
-                    (self,item) -> self.deriveUpdate(key, item),
-                    (self, exception) -> self.dispatchException(exception));
-            this.sourceObservers.add(observer);
-            this.sourceSubscriptions.add(obs.subscribe(observer, FIRST_UPDATE));
-        });
-    }
-
-    @Override
-    protected void subscriptionAdded(Observer<? super O> listener, Set<SubscriptionOption> options) {
-        synchronized (sourceObservers) {
-            if(subscriptionCount++ == 0) {
-                sourceObservers.forEach(PossiblyWeakObserver::makeStrong);
-            }
-        }
-    }
-
-    @Override
-    protected void subscriptionRemoved(Observer<? super O> listener) {
-        synchronized (sourceObservers) {
-            if (--subscriptionCount == 0) {
-                sourceObservers.forEach(PossiblyWeakObserver::makeWeak);
-            }
-        }
+        super.subscribeUpstreamWithFirstUpdate(sourceObservables);
     }
 
     public static <K, I, O> ObservableValue<O> derive(Map<K, ? extends Observable<I>> sourceObservables,
-            BiFunction<K, I, Optional<O>> mapper) {
+                                                      BiFunction<K, I, Optional<O>> mapper) {
         return new DerivedObservableValue<>(sourceObservables, mapper);
     }
 
@@ -87,49 +40,13 @@ public class DerivedObservableValue<K, I, O> extends DispatchingObservableValue<
         return new DerivedObservableValue<>(singletonMap(SINGLE, source), (k, v) -> mapper.apply(v));
     }
 
-    private void deriveUpdate(K key, I item) {
+    @Override
+    protected void applyOperation(K key, I item) {
         attempt(() -> mapper.apply(key, item)) //
                 .ifException(this::dispatchException) //
                 .optionalValue() //
                 .orElseGet(Optional::empty) //
                 .ifPresent(this::dispatchValue);
-    }
-
-    private static class PossiblyWeakObserver<C, T> implements Observer<T> {
-        private final WeakReference<C> holderRef;
-        private final AtomicReference<C> strongHolderRef;
-        private final BiConsumer<? super C, T> valueConsumer;
-        private final BiConsumer<? super C, Throwable> exceptionConsumer;
-
-        PossiblyWeakObserver(C holder, BiConsumer<? super C, T> valueConsumer,
-                BiConsumer<? super C, Throwable> exceptionConsumer) {
-            this.holderRef = new WeakReference<>(holder);
-            this.strongHolderRef = new AtomicReference<>();
-            this.valueConsumer = valueConsumer;
-            this.exceptionConsumer = exceptionConsumer;
-        }
-
-        public void makeStrong() {
-            strongHolderRef.set(holderRef.get());
-        }
-
-        public void makeWeak() {
-            strongHolderRef.set(null);
-        }
-
-        @Override
-        public void onValue(T t) {
-            dispatch(valueConsumer, t);
-        }
-
-        @Override
-        public void onException(Throwable t) {
-            dispatch(exceptionConsumer, t);
-        }
-
-        private <X> void dispatch(BiConsumer<? super C, X> consumer, X item) {
-            Optional.ofNullable(holderRef.get()).ifPresent(ref -> consumer.accept(ref, item));
-        }
     }
 
 }

--- a/src/main/java/org/ossgang/commons/observables/operators/connectors/AbstractConnectorObservableValue.java
+++ b/src/main/java/org/ossgang/commons/observables/operators/connectors/AbstractConnectorObservableValue.java
@@ -2,6 +2,7 @@ package org.ossgang.commons.observables.operators.connectors;
 
 import org.ossgang.commons.observables.DispatchingObservableValue;
 import org.ossgang.commons.observables.ObservableValue;
+import org.ossgang.commons.observables.Observers;
 import org.ossgang.commons.observables.Subscription;
 import org.ossgang.commons.properties.Properties;
 import org.ossgang.commons.properties.Property;
@@ -47,10 +48,7 @@ public abstract class AbstractConnectorObservableValue<T> extends DispatchingObs
                     disconnect();
                 }
                 upstreamObservable = requireNonNull(upstream, "Upstream observable cannot be null! Not connecting");
-                upstreamSubscription = upstreamObservable.subscribe(weakWithErrorAndSubscriptionCountHandling(this,
-                        (self, value) -> self.dispatchValue(value),
-                        (self, exception) -> self.dispatchException(exception),
-                        AbstractConnectorObservableValue::subscriberCountChanged), FIRST_UPDATE);
+                upstreamSubscription = upstreamObservable.subscribe(Observers.withErrorHandling(this::dispatchValue, this::dispatchException), FIRST_UPDATE);
                 connectionState.set(CONNECTED);
             } finally {
                 ongoingOperation = false;

--- a/src/main/java/org/ossgang/commons/observables/operators/connectors/AbstractConnectorObservableValue.java
+++ b/src/main/java/org/ossgang/commons/observables/operators/connectors/AbstractConnectorObservableValue.java
@@ -10,7 +10,6 @@ import org.ossgang.commons.properties.Property;
 import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
-import static org.ossgang.commons.observables.Observers.weakWithErrorAndSubscriptionCountHandling;
 import static org.ossgang.commons.observables.SubscriptionOptions.FIRST_UPDATE;
 import static org.ossgang.commons.observables.operators.connectors.ConnectorState.CONNECTED;
 import static org.ossgang.commons.observables.operators.connectors.ConnectorState.DISCONNECTED;

--- a/src/test/java/org/ossgang/commons/GcTests.java
+++ b/src/test/java/org/ossgang/commons/GcTests.java
@@ -20,14 +20,16 @@ public class GcTests {
     public static void forceGc() {
         for (int run = 0; run < 10; run++) {
             WeakReference<?> ref = new WeakReference<>(new Object());
-            Await.await(() -> {
-                System.gc();
-                return ref.get() == null;
-            }).withErrorMessage("Weak ref should have been collected already!")
-                    .withRetryInterval(Duration.ofMillis(100))
-                    .withRetryCount(100)
+            Await.await(() -> wasGarbageCollected(ref)) //
+                    .withErrorMessage("Weak ref should have been collected already!") //
+                    .withRetryInterval(Duration.ofMillis(100)) //
+                    .withRetryCount(100) //
                     .indefinitely();
         }
     }
 
+    public static boolean wasGarbageCollected(WeakReference<?> weakHolder) {
+        System.gc();
+        return weakHolder.get() == null;
+    }
 }

--- a/src/test/java/org/ossgang/commons/observables/ObservableOperatorsGcComplianceTest.java
+++ b/src/test/java/org/ossgang/commons/observables/ObservableOperatorsGcComplianceTest.java
@@ -5,14 +5,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.ossgang.commons.monads.Maybe;
+import org.ossgang.commons.properties.Properties;
+import org.ossgang.commons.properties.Property;
 
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ossgang.commons.GcTests.forceGc;
 
@@ -22,11 +27,11 @@ public class ObservableOperatorsGcComplianceTest {
     @Parameterized.Parameters(name = "{0}")
     public static Iterable<Object[]> parameters() {
         /* Unfortunate JUnit parametrized API... */
-        return Arrays.asList(new Object[][]{
-                {"Generic derive", (Function<ObservableValue<Object>, ObservableValue<Object>>) source -> source.derive(Optional::of)},
-                {"Map", (Function<ObservableValue<Object>, ObservableValue<Object>>) source -> source.map(Function.identity())},
-                {"Filter", (Function<ObservableValue<Object>, ObservableValue<Object>>) source -> source.filter(any -> true)}
-        });
+        return Arrays.asList(new Object[][] { { "Generic derive",
+                (Function<ObservableValue<Object>, ObservableValue<Object>>) source -> source.derive(Optional::of) },
+                { "Map", (Function<ObservableValue<Object>, ObservableValue<Object>>) source -> source
+                        .map(Function.identity()) }, { "Filter",
+                (Function<ObservableValue<Object>, ObservableValue<Object>>) source -> source.filter(any -> true) } });
     }
 
     @Parameterized.Parameter(0)
@@ -140,5 +145,26 @@ public class ObservableOperatorsGcComplianceTest {
         forceGc();
 
         assertThat(sourceWeak.get()).as("Holding operator without subscriber should keep source reachable").isNotNull();
+    }
+
+    @Test
+    public void gcWithMultipleDerivationsWhileNotSubscribedAndSourceReferenced_shouldGcDerivations() throws Exception {
+        Property<String> property = Properties.property("42");
+        ObservableValue<String> step1 = property.map(identity());
+        ObservableValue<Integer> step2 = step1.map(Integer::parseInt);
+        ObservableValue<Integer> step3 = step2.filter(any -> true);
+
+        WeakReference<?> step2ref = new WeakReference<>(step2);
+        step2 = null;
+        WeakReference<?> step3ref = new WeakReference<>(step3);
+        step3 = null;
+
+        for (int i = 0; i < 10; i++) {
+            forceGc();
+            Thread.sleep(10); /* allow weak observer stale cleanup to happen */
+        }
+
+        assertThat(step3ref.get()).isNull();
+        assertThat(step2ref.get()).isNull();
     }
 }

--- a/src/test/java/org/ossgang/commons/observables/ObservableOperatorsGcComplianceTest.java
+++ b/src/test/java/org/ossgang/commons/observables/ObservableOperatorsGcComplianceTest.java
@@ -1,13 +1,10 @@
 package org.ossgang.commons.observables;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.ossgang.commons.awaitables.Await;
-import org.ossgang.commons.monads.Maybe;
-import org.ossgang.commons.properties.Properties;
-import org.ossgang.commons.properties.Property;
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ossgang.commons.GcTests.forceGc;
+import static org.ossgang.commons.GcTests.wasGarbageCollected;
 
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
@@ -16,11 +13,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import static java.time.Duration.ofMillis;
-import static java.time.Duration.ofSeconds;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.ossgang.commons.GcTests.forceGc;
-import static org.ossgang.commons.GcTests.wasGarbageCollected;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.ossgang.commons.awaitables.Await;
+import org.ossgang.commons.monads.Maybe;
+import org.ossgang.commons.properties.Properties;
+import org.ossgang.commons.properties.Property;
 
 @RunWith(Parameterized.class)
 public class ObservableOperatorsGcComplianceTest {

--- a/src/test/java/org/ossgang/commons/observables/ObservableOperatorsGcComplianceTest.java
+++ b/src/test/java/org/ossgang/commons/observables/ObservableOperatorsGcComplianceTest.java
@@ -1,0 +1,144 @@
+package org.ossgang.commons.observables;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.ossgang.commons.monads.Maybe;
+
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ossgang.commons.GcTests.forceGc;
+
+@RunWith(Parameterized.class)
+public class ObservableOperatorsGcComplianceTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<Object[]> parameters() {
+        /* Unfortunate JUnit parametrized API... */
+        return Arrays.asList(new Object[][]{
+                {"Generic derive", (Function<ObservableValue<Object>, ObservableValue<Object>>) source -> source.derive(Optional::of)},
+                {"Map", (Function<ObservableValue<Object>, ObservableValue<Object>>) source -> source.map(Function.identity())},
+                {"Filter", (Function<ObservableValue<Object>, ObservableValue<Object>>) source -> source.filter(any -> true)}
+        });
+    }
+
+    @Parameterized.Parameter(0)
+    public String operatorName;
+
+    @Parameterized.Parameter(1)
+    public Function<ObservableValue<Object>, ObservableValue<Object>> operator;
+
+    private CompletableFuture<Object> result;
+
+    @Before
+    public void setUp() {
+        result = new CompletableFuture<>();
+    }
+
+    private void setResult(Object obj) {
+        result.complete(obj);
+    }
+
+    private Object getResult() {
+        return Maybe.attempt(() -> result.get(5, TimeUnit.SECONDS)).value();
+    }
+
+    @Test
+    public void whileSubscribed_holdingSource_shouldPreventGc() {
+        Dispatcher<Object> source = Observables.dispatcher();
+        ObservableValue<Object> operatorStep = operator.apply(source);
+        Subscription subscription = operatorStep.subscribe(this::setResult);
+
+        WeakReference<?> operatorStepWeak = new WeakReference<>(operatorStep);
+        operatorStep = null;
+        WeakReference<?> subscriptionWeak = new WeakReference<>(subscription);
+        subscription = null;
+
+        forceGc();
+
+        source.dispatchValue(1);
+        assertThat(getResult()).as("Value flow should be kept").isEqualTo(1);
+
+        assertThat(operatorStepWeak.get()).as("Referencing source should keep operator reachable").isNotNull();
+        assertThat(subscriptionWeak.get()).as("Referencing source should keep subscription reachable").isNotNull();
+    }
+
+    @Test
+    public void whileSubscribed_holdingOperator_shouldPreventGc() {
+        Dispatcher<Object> source = Observables.dispatcher();
+        ObservableValue<Object> operatorStep = operator.apply(source);
+        Subscription subscription = operatorStep.subscribe(this::setResult);
+
+        WeakReference<Dispatcher<Object>> sourceWeak = new WeakReference<>(source);
+        source = null;
+        WeakReference<?> subscriptionWeak = new WeakReference<>(subscription);
+        subscription = null;
+
+        forceGc();
+
+        assertThat(sourceWeak.get()).as("Holding operator should keep source reachable").isNotNull();
+        sourceWeak.get().dispatchValue(1);
+        assertThat(getResult()).as("Value flow should be kept").isEqualTo(1);
+
+        forceGc();
+
+        assertThat(sourceWeak.get()).as("Holding operator should keep source reachable").isNotNull();
+        assertThat(subscriptionWeak.get()).as("Holding operator should keep subscription reachable").isNotNull();
+    }
+
+    @Test
+    public void holdingSubscription_shouldPreventGc() {
+        Dispatcher<Object> source = Observables.dispatcher();
+        ObservableValue<Object> operatorStep = operator.apply(source);
+        Subscription subscription = operatorStep.subscribe(this::setResult);
+
+        WeakReference<Dispatcher<Object>> sourceWeak = new WeakReference<>(source);
+        source = null;
+        WeakReference<?> operatorStepWeak = new WeakReference<>(operatorStep);
+        operatorStep = null;
+
+        forceGc();
+
+        assertThat(sourceWeak.get()).as("Holding subscription should keep source reachable").isNotNull();
+        sourceWeak.get().dispatchValue(1);
+        assertThat(getResult()).as("Value flow should be kept").isEqualTo(1);
+
+        forceGc();
+
+        assertThat(sourceWeak.get()).as("Holding subscription should keep source reachable").isNotNull();
+        assertThat(operatorStepWeak.get()).as("Holding subscription should keep operator reachable").isNotNull();
+    }
+
+    @Test
+    public void withoutSubscriber_holdingSource_shouldGcOperator() {
+        Dispatcher<Object> source = Observables.dispatcher();
+        ObservableValue<Object> operatorStep = operator.apply(source);
+
+        WeakReference<?> operatorStepWeak = new WeakReference<>(operatorStep);
+        operatorStep = null;
+
+        forceGc();
+
+        assertThat(operatorStepWeak.get()).as("Referencing source without subscriber should GC operator").isNull();
+    }
+
+    @Test
+    public void withoutSubscriber_holdingOperator_shouldPreventGcOfSource() {
+        Dispatcher<Object> source = Observables.dispatcher();
+        ObservableValue<Object> operatorStep = operator.apply(source);
+
+        WeakReference<Dispatcher<Object>> sourceWeak = new WeakReference<>(source);
+        source = null;
+
+        forceGc();
+
+        assertThat(sourceWeak.get()).as("Holding operator without subscriber should keep source reachable").isNotNull();
+    }
+}

--- a/src/test/java/org/ossgang/commons/observables/ObservableValueGcTest.java
+++ b/src/test/java/org/ossgang/commons/observables/ObservableValueGcTest.java
@@ -1,6 +1,5 @@
 package org.ossgang.commons.observables;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ossgang.commons.GcTests.forceGc;
 
@@ -20,13 +19,11 @@ public class ObservableValueGcTest {
     }
 
     @Test
-    public void gcWhileSubscribed_shouldPreventGc() throws Exception {
+    public void gcWithSourceDiscardedWhileSubscribed_shouldGc() throws Exception {
         WeakReference<Property<Integer>> weakProp = gcWhileSubscribed_shouldPreventGc_subscribe();
         forceGc();
         Property<Integer> prop = weakProp.get();
-        assertThat(prop).isNotNull();
-        prop.set(2);
-        assertThat(methodReferenceUpdateValue.get(1, SECONDS)).isEqualTo(2);
+        assertThat(prop).isNull();
     }
 
     private WeakReference<Property<Integer>> gcWhileSubscribed_shouldPreventGc_subscribe() {

--- a/src/test/java/org/ossgang/commons/observables/WeakObserverTest.java
+++ b/src/test/java/org/ossgang/commons/observables/WeakObserverTest.java
@@ -4,7 +4,6 @@ import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.ossgang.commons.GcTests.forceGc;
 import static org.ossgang.commons.GcTests.wasGarbageCollected;
 
 import java.lang.ref.WeakReference;
@@ -72,6 +71,8 @@ public class WeakObserverTest {
         Await.await(() -> wasGarbageCollected(weakHolder)).withRetryInterval(ofMillis(10))
                 .withErrorMessage("Holder should be collected since WeakObserver should not keep a reference to it!")
                 .atMost(ofSeconds(5));
+
+        Thread.sleep(100); /* allow the WeakObserver cleanup to run */
 
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> source.subscribe(observerRef.get()))
                 .withMessageContaining("Weak observer has been garbage collected");

--- a/src/test/java/org/ossgang/commons/observables/WeakObserverTest.java
+++ b/src/test/java/org/ossgang/commons/observables/WeakObserverTest.java
@@ -72,7 +72,9 @@ public class WeakObserverTest {
                 .withErrorMessage("Holder should be collected since WeakObserver should not keep a reference to it!")
                 .atMost(ofSeconds(5));
 
-        Thread.sleep(100); /* allow the WeakObserver cleanup to run */
+        Await.await(() -> observerRef.get().isCleanedUp()).withRetryInterval(ofMillis(10))
+                .withErrorMessage("WeakObserver should be cleaned up!")
+                .atMost(ofSeconds(5));
 
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> source.subscribe(observerRef.get()))
                 .withMessageContaining("Weak observer has been garbage collected");

--- a/src/test/java/org/ossgang/commons/observables/WeakObserverTest.java
+++ b/src/test/java/org/ossgang/commons/observables/WeakObserverTest.java
@@ -1,7 +1,8 @@
 package org.ossgang.commons.observables;
 
-import org.junit.Test;
-import org.ossgang.commons.awaitables.Await;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ossgang.commons.observables.WeakMethodReferenceObserver.DEFAULT_CLEANUP_PERIOD_SEC;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.CountDownLatch;
@@ -9,9 +10,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import static java.time.Duration.ofSeconds;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.ossgang.commons.observables.WeakMethodReferenceObserver.DEFAULT_CLEANUP_PERIOD_SEC;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.ossgang.commons.awaitables.Await;
 
 public class WeakObserverTest {
 
@@ -23,6 +24,7 @@ public class WeakObserverTest {
     };
 
     @Test
+    @Ignore("takes too long")
     public void weakObserver_whenHolderIsCollected_shouldUnsubscribe() throws Exception {
         Object holder = new Object();
         CountDownLatch unSubscribed = new CountDownLatch(1);
@@ -44,6 +46,7 @@ public class WeakObserverTest {
     }
 
     @Test
+    @Ignore("takes too long")
     public void weakObserver_whenHolderIsStronglyReferenced_shouldNotUnsubscribe() throws InterruptedException {
         Object holder = new Object();
 

--- a/src/test/java/org/ossgang/commons/observables/WeakObserverTest.java
+++ b/src/test/java/org/ossgang/commons/observables/WeakObserverTest.java
@@ -1,8 +1,8 @@
 package org.ossgang.commons.observables;
 
+import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.ossgang.commons.observables.WeakMethodReferenceObserver.DEFAULT_CLEANUP_PERIOD_SEC;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.CountDownLatch;
@@ -10,21 +10,17 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.ossgang.commons.awaitables.Await;
 
 public class WeakObserverTest {
 
-    public static final BiConsumer<Object, Object> NOOP_ON_VALUE = (h, v) -> {
+    private static final BiConsumer<Object, Object> NOOP_ON_VALUE = (h, v) -> {
     };
-    public static final BiConsumer<Object, Throwable> NOOP_ON_EXCEPTION = (h, e) -> {
-    };
-    public static final BiConsumer<Object, Integer> NOOP_SUBSCRIBER_COUNTING = (h, i) -> {
+    private static final BiConsumer<Object, Throwable> NOOP_ON_EXCEPTION = (h, e) -> {
     };
 
     @Test
-    @Ignore("takes too long")
     public void weakObserver_whenHolderIsCollected_shouldUnsubscribe() throws Exception {
         Object holder = new Object();
         CountDownLatch unSubscribed = new CountDownLatch(1);
@@ -36,17 +32,16 @@ public class WeakObserverTest {
         holder = null;
 
         Await.await(() -> wasGarbageCollected(weakHolder))
-                .withRetryInterval(ofSeconds(1))
+                .withRetryInterval(ofMillis(10))
                 .withErrorMessage("Holder should be collected since WeakObserver should not keep a reference to it!")
-                .atMost(ofSeconds(DEFAULT_CLEANUP_PERIOD_SEC * 2));
+                .atMost(ofSeconds(5));
 
-        assertThat(unSubscribed.await(DEFAULT_CLEANUP_PERIOD_SEC * 2, TimeUnit.SECONDS))
+        assertThat(unSubscribed.await(5, TimeUnit.SECONDS))
                 .as("Subscriber should have been unsubscribed by now because the holder was collected")
                 .isTrue();
     }
 
     @Test
-    @Ignore("takes too long")
     public void weakObserver_whenHolderIsStronglyReferenced_shouldNotUnsubscribe() throws InterruptedException {
         Object holder = new Object();
 
@@ -55,13 +50,13 @@ public class WeakObserverTest {
         Dispatcher<Object> source = Observables.dispatcher();
         source.subscribe(newWeakObserver(holder, s -> unSubscribed.countDown()));
 
-        assertThat(unSubscribed.await(DEFAULT_CLEANUP_PERIOD_SEC * 2, TimeUnit.SECONDS))
+        assertThat(unSubscribed.await(1, TimeUnit.SECONDS))
                 .as("Subscriber should NOT have been unsubscribed because there is a strong reference to the holder!")
                 .isFalse();
     }
 
     private static WeakMethodReferenceObserver<Object, Object> newWeakObserver(Object holder, Consumer<Subscription> onUnsubscribe) {
-        return new WeakMethodReferenceObserver<Object, Object>(holder, NOOP_ON_VALUE, NOOP_ON_EXCEPTION, NOOP_SUBSCRIBER_COUNTING) {
+        return new WeakMethodReferenceObserver<Object, Object>(holder, NOOP_ON_VALUE, NOOP_ON_EXCEPTION) {
             @Override
             public void onUnsubscribe(Subscription subscription) {
                 super.onUnsubscribe(subscription);

--- a/src/test/java/org/ossgang/commons/observables/operators/AbstractOperatorObservableValueGcTest.java
+++ b/src/test/java/org/ossgang/commons/observables/operators/AbstractOperatorObservableValueGcTest.java
@@ -1,5 +1,6 @@
 package org.ossgang.commons.observables.operators;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.ossgang.commons.observables.ObservableValue;
 import org.ossgang.commons.observables.Observer;
@@ -20,8 +21,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.ossgang.commons.GcTests.forceGc;
 import static org.ossgang.commons.observables.operators.DerivedObservableValue.derive;
 
-public class DerivedObservableValueGcTest {
-    private CompletableFuture<Integer> methodReferenceUpdateValue = new CompletableFuture<>();
+public class AbstractOperatorObservableValueGcTest {
+
+    private CompletableFuture<Integer> methodReferenceUpdateValue;
+
+    @Before
+    public void setUp() {
+        methodReferenceUpdateValue = new CompletableFuture<>();
+    }
 
     private void handleUpdate(int test) {
         methodReferenceUpdateValue.complete(test);
@@ -205,6 +212,7 @@ public class DerivedObservableValueGcTest {
         assertThat(step3ref.get()).isNull();
     }
 
+    @SuppressWarnings("UnusedAssignment")
     @Test
     public void gcMultipleDerivationWithoutSubscriberAndMidStageReferenced_shouldKeepUpstreamOfMidStageAndGcDanglingStage() {
         Property<String> source = Properties.property("42");
@@ -222,6 +230,7 @@ public class DerivedObservableValueGcTest {
         assertThat(danglingStepRef.get()).isNull();
     }
 
+    @SuppressWarnings("UnusedAssignment")
     @Test
     public void gcMultipleDerivationWithSubscriberAndOnlySourceReferenced_shouldPreventGc() throws Exception {
         Property<String> source = Properties.property("42");
@@ -242,8 +251,9 @@ public class DerivedObservableValueGcTest {
         assertThat(methodReferenceUpdateValue.get(5, SECONDS)).isEqualTo(1);
     }
 
+    @SuppressWarnings("UnusedAssignment")
     @Test
-    public void gcMultipleDerivationWithSubscriberAndOnlySubscriberReferenced_shouldPreventGc() throws Exception {
+    public void gcMultipleDerivationWithSubscriberAndOnlySubscriptionReferenced_shouldPreventGc() throws Exception {
         Property<String> source = Properties.property("42");
         ObservableValue<Integer> midStep = source.map(Integer::parseInt);
         Subscription subscription = midStep.subscribe(this::handleUpdate);

--- a/src/test/java/org/ossgang/commons/observables/operators/DerivedObservableValueGcTest.java
+++ b/src/test/java/org/ossgang/commons/observables/operators/DerivedObservableValueGcTest.java
@@ -2,6 +2,7 @@ package org.ossgang.commons.observables.operators;
 
 import static java.lang.Integer.parseInt;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ossgang.commons.GcTests.forceGc;
 import static org.ossgang.commons.observables.operators.DerivedObservableValue.derive;
@@ -27,13 +28,11 @@ public class DerivedObservableValueGcTest {
     }
 
     @Test
-    public void gcWhileSubscribed_shouldPreventGcOfUpstream() throws Exception {
+    public void gcWhileSubscribed_shouldNotPreventGcOfUpstream() throws Exception {
         WeakReference<Property<String>> property = gcWhileSubscribed_shouldPreventGcOfUpstream_subscribe();
         forceGc();
         Property<String> prop = property.get();
-        assertThat(prop).isNotNull();
-        prop.set("3");
-        assertThat(methodReferenceUpdateValue.get(1, SECONDS)).isEqualTo(3);
+        assertThat(prop).isNull();
     }
 
     private WeakReference<Property<String>> gcWhileSubscribed_shouldPreventGcOfUpstream_subscribe() {
@@ -71,20 +70,109 @@ public class DerivedObservableValueGcTest {
                 return property.get();
             }
         };
-        WeakReference<ObservableValue<Integer>> derivedObservable = gcWhileSubscribedButUpstreamSubscriptionKilled_derive(wrappedProperty);
+        WeakReference<ObservableValue<Integer>> derivedObservable = gcWhileSubscribedButUpstreamSubscriptionKilled_derive(
+                wrappedProperty);
         assertThat(derivedObservable.get()).isNotNull();
         forceGc(); /* downstream listener and upstream subscription intact => GC protected */
         assertThat(derivedObservable.get()).isNotNull();
         property.set("1");
         assertThat(methodReferenceUpdateValue.get(5, SECONDS)).isEqualTo(1);
         upstreamSubscription.get().unsubscribe();
+        upstreamSubscription.set(null);
         forceGc(); /*  upstream subscription killed => not GC protected anymore */
         assertThat(derivedObservable.get()).isNull();
     }
 
-    private WeakReference<ObservableValue<Integer>> gcWhileSubscribedButUpstreamSubscriptionKilled_derive(ObservableValue<String> value) {
+    private WeakReference<ObservableValue<Integer>> gcWhileSubscribedButUpstreamSubscriptionKilled_derive(
+            ObservableValue<String> value) {
         ObservableValue<Integer> derived = derive(value, v -> Optional.of(parseInt(v)));
         derived.subscribe(this::handleUpdate);
         return new WeakReference<>(derived);
+    }
+
+    @SuppressWarnings("UnusedAssignment")
+    @Test
+    public void gcWithMultipleDerivationsWhileSubscribedAndSourceReferenced_shouldPreventGc() throws Exception {
+        Property<String> property = Properties.property("42");
+        ObservableValue<String> step1 = property.map(identity());
+        ObservableValue<Integer> step2 = step1.map(Integer::parseInt);
+        ObservableValue<Integer> step3 = step2.filter(any -> true);
+
+        step3.subscribe(this::handleUpdate);
+
+        WeakReference<?> step1ref = new WeakReference<>(step1);
+        step1 = null;
+        WeakReference<?> step2ref = new WeakReference<>(step2);
+        step2 = null;
+        WeakReference<?> step3ref = new WeakReference<>(step3);
+        step3 = null;
+
+        forceGc();
+        property.set("1");
+        assertThat(methodReferenceUpdateValue.get(5, SECONDS)).isEqualTo(1);
+
+        forceGc();
+        assertThat(step1ref.get()).isNotNull();
+        assertThat(step2ref.get()).isNotNull();
+        assertThat(step3ref.get()).isNotNull();
+    }
+
+    @SuppressWarnings("UnusedAssignment")
+    @Test
+    public void gcWithMultipleDerivationsWhileSubscribedAndIntermediateStageReferenced_shouldPreventGc() throws Exception {
+        Property<String> property = Properties.property("42");
+        ObservableValue<String> step1 = property.map(identity());
+        ObservableValue<Integer> step2 = step1.map(Integer::parseInt);
+        ObservableValue<Integer> step3 = step2.filter(any -> true);
+
+        step3.subscribe(this::handleUpdate);
+
+        WeakReference<Property<String>> propertyRef = new WeakReference<>(property);
+        property = null;
+        WeakReference<?> step1ref = new WeakReference<>(step1);
+        step1 = null;
+        WeakReference<?> step2ref = new WeakReference<>(step2);
+        step2 = null;
+
+        forceGc();
+
+        property = propertyRef.get();
+        assertThat(property).isNotNull();
+        assertThat(step1ref.get()).isNotNull();
+        assertThat(step2ref.get()).isNotNull();
+        property.set("1");
+        assertThat(methodReferenceUpdateValue.get(5, SECONDS)).isEqualTo(1);
+    }
+
+    @SuppressWarnings("UnusedAssignment")
+    @Test
+    public void gcWithMultipleDerivationsWhileSubscribedAndNoStageReferenced_shouldGc() throws Exception {
+        Property<String> property = Properties.property("42");
+        ObservableValue<String> step1 = property.map(identity());
+        ObservableValue<Integer> step2 = step1.map(Integer::parseInt);
+        ObservableValue<Integer> step3 = step2.filter(any -> true);
+
+        Subscription subscriptionThatShouldNotPreventGc = step3.subscribe(this::handleUpdate);
+
+        WeakReference<?> step1ref = new WeakReference<>(step1);
+        step1 = null;
+        WeakReference<?> step2ref = new WeakReference<>(step2);
+        step2 = null;
+        WeakReference<?> step3ref = new WeakReference<>(step3);
+        step3 = null;
+
+        forceGc();
+        property.set("1");
+        assertThat(methodReferenceUpdateValue.get(5, SECONDS)).isEqualTo(1);
+
+        WeakReference<?> propertyRef = new WeakReference<>(property);
+        property = null;
+        forceGc();
+        assertThat(propertyRef.get()).isNull();
+        assertThat(step1ref.get()).isNull();
+        assertThat(step2ref.get()).isNull();
+        assertThat(step3ref.get()).isNull();
+        subscriptionThatShouldNotPreventGc.unsubscribe();
+        assertThat(subscriptionThatShouldNotPreventGc).isNotNull();
     }
 }


### PR DESCRIPTION
Instead, make sure that derivations keep the upstream observables alive, and are kept alive themselves (by the upstream) as long as subscriptions exist.

Signed-off-by: mihostet <michi.hostettler@cern.ch>