### PR TITLE
add "general" decimal format helper

### DIFF
--- a/src/main/java/org/ossgang/commons/utils/GeneralDecimalFormat.java
+++ b/src/main/java/org/ossgang/commons/utils/GeneralDecimalFormat.java
@@ -18,11 +18,20 @@ public class GeneralDecimalFormat extends NumberFormat {
     private final double lowExponentialThreshold;
     private final double highExponentialThreshold;
 
-    public GeneralDecimalFormat(String pattern, double lowExponentialThreshold, double highExponentialThreshold) {
-        fixedFormat = new DecimalFormat(pattern);
-        exponentialFormat = new DecimalFormat(pattern + "E0");
+    public GeneralDecimalFormat(DecimalFormat fixedFormat, DecimalFormat exponentialFormat,
+            double lowExponentialThreshold, double highExponentialThreshold) {
+        if (lowExponentialThreshold <= 0 || highExponentialThreshold <= 0) {
+            throw new IllegalArgumentException("Thresholds must be > 0!");
+        }
+        this.fixedFormat = fixedFormat;
+        this.exponentialFormat = exponentialFormat;
         this.lowExponentialThreshold = lowExponentialThreshold;
         this.highExponentialThreshold = highExponentialThreshold;
+    }
+
+    public GeneralDecimalFormat(String pattern, double lowExponentialThreshold, double highExponentialThreshold) {
+        this(new DecimalFormat(pattern), new DecimalFormat(pattern + "E0"), lowExponentialThreshold,
+                highExponentialThreshold);
     }
 
     public GeneralDecimalFormat(int integerDigits, int fractionDigits) {

--- a/src/main/java/org/ossgang/commons/utils/GeneralDecimalFormat.java
+++ b/src/main/java/org/ossgang/commons/utils/GeneralDecimalFormat.java
@@ -1,0 +1,68 @@
+package org.ossgang.commons.utils;
+
+import static java.lang.Math.pow;
+
+import java.text.DecimalFormat;
+import java.text.FieldPosition;
+import java.text.NumberFormat;
+import java.text.ParsePosition;
+
+/**
+ * A Decimal Format that behaves similar to the format string "%g" ("general"): if the number is representable with
+ * a small number of digits, using fixed-point formatting, use fixed point. If it is too small or too big, fall back to
+ * scientific format.
+ */
+public class GeneralDecimalFormat extends NumberFormat {
+    private final DecimalFormat fixedFormat;
+    private final DecimalFormat exponentialFormat;
+    private final double lowExponentialThreshold;
+    private final double highExponentialThreshold;
+
+    public GeneralDecimalFormat(String pattern, double lowExponentialThreshold, double highExponentialThreshold) {
+        fixedFormat = new DecimalFormat(pattern);
+        exponentialFormat = new DecimalFormat(pattern + "E0");
+        this.lowExponentialThreshold = lowExponentialThreshold;
+        this.highExponentialThreshold = highExponentialThreshold;
+    }
+
+    public GeneralDecimalFormat(int integerDigits, int fractionDigits) {
+        this(buildDefaultPattern(fractionDigits), pow(10, -fractionDigits), pow(10, integerDigits));
+    }
+
+    public GeneralDecimalFormat() {
+        this(6, 3);
+    }
+
+    private static String buildDefaultPattern(int numberOfDigits) {
+        StringBuilder pattern = new StringBuilder("0.");
+        for (int i = 0; i < numberOfDigits; i++) {
+            pattern.append('#');
+        }
+        return pattern.toString();
+    }
+
+    @Override
+    public StringBuffer format(double number, StringBuffer toAppendTo, FieldPosition pos) {
+        double val = Math.abs(number);
+        if (val >= highExponentialThreshold || (val <= lowExponentialThreshold && val > 0.0)) {
+            return exponentialFormat.format(number, toAppendTo, pos);
+        } else {
+            return fixedFormat.format(number, toAppendTo, pos);
+        }
+    }
+
+    @Override
+    public StringBuffer format(long number, StringBuffer toAppendTo, FieldPosition pos) {
+        long val = Math.abs(number);
+        if (val >= highExponentialThreshold) {
+            return exponentialFormat.format(number, toAppendTo, pos);
+        } else {
+            return fixedFormat.format(number, toAppendTo, pos);
+        }
+    }
+
+    @Override
+    public Number parse(String source, ParsePosition parsePosition) {
+        return exponentialFormat.parse(source, parsePosition);
+    }
+}

--- a/src/main/java/org/ossgang/commons/utils/GeneralDecimalFormat.java
+++ b/src/main/java/org/ossgang/commons/utils/GeneralDecimalFormat.java
@@ -30,8 +30,15 @@ public class GeneralDecimalFormat extends NumberFormat {
     }
 
     public GeneralDecimalFormat(String pattern, double lowExponentialThreshold, double highExponentialThreshold) {
-        this(new DecimalFormat(pattern), new DecimalFormat(pattern + "E0"), lowExponentialThreshold,
+        this(new DecimalFormat(pattern), new DecimalFormat(buildDefaultExponentialPattern(pattern)), lowExponentialThreshold,
                 highExponentialThreshold);
+    }
+
+    private static String buildDefaultExponentialPattern(String pattern) {
+        if (pattern.contains("E")) {
+            throw new UnsupportedOperationException("The pattern must not contain an exponential specifier ('E')");
+        }
+        return pattern + "E0";
     }
 
     public GeneralDecimalFormat(int integerDigits, int fractionDigits) {

--- a/src/main/java/org/ossgang/commons/utils/GeneralDecimalFormat.java
+++ b/src/main/java/org/ossgang/commons/utils/GeneralDecimalFormat.java
@@ -36,7 +36,7 @@ public class GeneralDecimalFormat extends NumberFormat {
 
     private static String buildDefaultExponentialPattern(String pattern) {
         if (pattern.contains("E")) {
-            throw new UnsupportedOperationException("The pattern must not contain an exponential specifier ('E')");
+            throw new IllegalArgumentException("The pattern must not contain an exponential specifier ('E')");
         }
         return pattern + "E0";
     }

--- a/src/test/java/org/ossgang/commons/utils/GeneralDecimalFormatTest.java
+++ b/src/test/java/org/ossgang/commons/utils/GeneralDecimalFormatTest.java
@@ -1,0 +1,47 @@
+package org.ossgang.commons.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GeneralDecimalFormatTest {
+
+    private GeneralDecimalFormat format = new GeneralDecimalFormat(6, 4);
+
+    @org.junit.Test
+    public void format_normalDouble_shouldFormatFixed() {
+        assertThat(format.format(42.0)).isEqualTo("42");
+        assertThat(format.format(42.42)).isEqualTo("42.42");
+        assertThat(format.format(0.42)).isEqualTo("0.42");
+        assertThat(format.format(0.0)).isEqualTo("0");
+        assertThat(format.format(99999.9)).isEqualTo("99999.9");
+    }
+
+    @org.junit.Test
+    public void format_normalLong_shouldFormatFixed() {
+        assertThat(format.format(0)).isEqualTo("0");
+        assertThat(format.format(1)).isEqualTo("1");
+        assertThat(format.format(42)).isEqualTo("42");
+        assertThat(format.format(42000)).isEqualTo("42000");
+        assertThat(format.format(99999)).isEqualTo("99999");
+    }
+
+    @org.junit.Test
+    public void format_tinyDouble_shouldFormatExponential() {
+        assertThat(format.format(0.0001)).isEqualTo("1E-4");
+        assertThat(format.format(0.00003)).isEqualTo("3E-5");
+        assertThat(format.format(42e-9)).isEqualTo("4.2E-8");
+        assertThat(format.format(1e-42)).isEqualTo("1E-42");
+    }
+
+    @org.junit.Test
+    public void format_bigDouble_shouldFormatExponential() {
+        assertThat(format.format(1000000.0)).isEqualTo("1E6");
+        assertThat(format.format(4242424.42)).isEqualTo("4.2424E6");
+    }
+
+    @org.junit.Test
+    public void format_bigLong_shouldFormatExponential() {
+        assertThat(format.format(1000000)).isEqualTo("1E6");
+        assertThat(format.format(4242424)).isEqualTo("4.2424E6");
+        assertThat(format.format(123000000)).isEqualTo("1.23E8");
+    }
+}

--- a/src/test/java/org/ossgang/commons/utils/GeneralDecimalFormatTest.java
+++ b/src/test/java/org/ossgang/commons/utils/GeneralDecimalFormatTest.java
@@ -1,6 +1,11 @@
 package org.ossgang.commons.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.text.DecimalFormat;
+
+import org.junit.Test;
 
 public class GeneralDecimalFormatTest {
 
@@ -45,12 +50,22 @@ public class GeneralDecimalFormatTest {
         assertThat(format.format(123000000)).isEqualTo("1.23E8");
     }
 
-
     @org.junit.Test
     public void format_customOptions_shouldFormatAccordingly() {
         assertThat(new GeneralDecimalFormat(1, 1).format(42.42)).isEqualTo("4.2E1");
         assertThat(new GeneralDecimalFormat(11, 1).format(42000000000.0)).isEqualTo("42000000000");
         assertThat(new GeneralDecimalFormat(4, 4).format(9999.9999)).isEqualTo("9999.9999");
+        assertThat(new GeneralDecimalFormat("000.000", 1e-3, 1e3) .format(9999.9999)).isEqualTo("100.000E2");
+        assertThat(new GeneralDecimalFormat("000.000", 1e-3, 1e3) .format(999.9)).isEqualTo("999.900");
+        assertThat(new GeneralDecimalFormat(new DecimalFormat("0.00"),new DecimalFormat("0.0E0"), 1e-3, 1e3) .format(999.9)).isEqualTo("999.90");
+        assertThat(new GeneralDecimalFormat(new DecimalFormat("0.00"),new DecimalFormat("0.0E0"), 1e-3, 1e3) .format(4242.4242)).isEqualTo("4.2E3");
+    }
+
+    @Test
+    public void construct_invalidCustomOptions_shouldThrow() {
+        assertThatExceptionOfType(UnsupportedOperationException.class) //
+                .isThrownBy(() -> new GeneralDecimalFormat("0.0E0", 1e-1, 10)) //
+                .withMessageContaining("pattern");
     }
 
 }

--- a/src/test/java/org/ossgang/commons/utils/GeneralDecimalFormatTest.java
+++ b/src/test/java/org/ossgang/commons/utils/GeneralDecimalFormatTest.java
@@ -63,7 +63,7 @@ public class GeneralDecimalFormatTest {
 
     @Test
     public void construct_invalidCustomOptions_shouldThrow() {
-        assertThatExceptionOfType(UnsupportedOperationException.class) //
+        assertThatExceptionOfType(IllegalArgumentException.class) //
                 .isThrownBy(() -> new GeneralDecimalFormat("0.0E0", 1e-1, 10)) //
                 .withMessageContaining("pattern");
     }

--- a/src/test/java/org/ossgang/commons/utils/GeneralDecimalFormatTest.java
+++ b/src/test/java/org/ossgang/commons/utils/GeneralDecimalFormatTest.java
@@ -12,7 +12,7 @@ public class GeneralDecimalFormatTest {
         assertThat(format.format(42.42)).isEqualTo("42.42");
         assertThat(format.format(0.42)).isEqualTo("0.42");
         assertThat(format.format(0.0)).isEqualTo("0");
-        assertThat(format.format(99999.9)).isEqualTo("99999.9");
+        assertThat(format.format(999999.9)).isEqualTo("999999.9");
     }
 
     @org.junit.Test
@@ -21,7 +21,7 @@ public class GeneralDecimalFormatTest {
         assertThat(format.format(1)).isEqualTo("1");
         assertThat(format.format(42)).isEqualTo("42");
         assertThat(format.format(42000)).isEqualTo("42000");
-        assertThat(format.format(99999)).isEqualTo("99999");
+        assertThat(format.format(999999)).isEqualTo("999999");
     }
 
     @org.junit.Test
@@ -44,4 +44,13 @@ public class GeneralDecimalFormatTest {
         assertThat(format.format(4242424)).isEqualTo("4.2424E6");
         assertThat(format.format(123000000)).isEqualTo("1.23E8");
     }
+
+
+    @org.junit.Test
+    public void format_customOptions_shouldFormatAccordingly() {
+        assertThat(new GeneralDecimalFormat(1, 1).format(42.42)).isEqualTo("4.2E1");
+        assertThat(new GeneralDecimalFormat(11, 1).format(42000000000.0)).isEqualTo("42000000000");
+        assertThat(new GeneralDecimalFormat(4, 4).format(9999.9999)).isEqualTo("9999.9999");
+    }
+
 }


### PR DESCRIPTION
A variant of DecimalFormat that tries to be a bit smarter and mimics the format style "%g" (general, [spec](https://pubs.opengroup.org/onlinepubs/009695399/functions/printf.html)):

> The double argument shall be converted in the style f or e (or in the style F or E in the case of a G conversion specifier), with the precision specifying the number of significant digits. If an explicit precision is zero, it shall be taken as 1. The style used depends on the value converted; style e (or E ) shall be used only if the exponent resulting from such a conversion is less than -4 or greater than or equal to the precision.

The threshold (both low and high) for switching to scientific format are configurable. There is a default constructor that tries to provide a compromise for "common" cases (exponential if >= 1e6 or <= 1e-4).